### PR TITLE
Add first implementation of carbon-crypto-provider-hsm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,17 @@
-# Compiled class file
-*.class
-
 # Log file
 *.log
 
 # BlueJ files
 *.ctxt
+
+*.class
+.classpath
+.settings
+.project
+*.iml
+*.iws
+*.ipr
+.idea
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -13,11 +19,13 @@
 # Package Files #
 *.jar
 *.war
-*.nar
 *.ear
+*.nar
 *.zip
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Ignore everything in this directory
+target

--- a/components/org.wso2.carbon.crypto.provider.hsm/pom.xml
+++ b/components/org.wso2.carbon.crypto.provider.hsm/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>carbon-crypto-provider-hsm</artifactId>
         <groupId>org.wso2.carbon.crypto</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -142,7 +142,6 @@
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.crypto.provider.hsm.internal,
-                            org.wso2.carbon.crypto.provider.hsm.cryptoprovider; version="${project.version}",
                             org.wso2.carbon.crypto.provider.hsm.*; version="${project.version}",
                         </Export-Package>
                     </instructions>

--- a/components/org.wso2.carbon.crypto.provider.hsm/pom.xml
+++ b/components/org.wso2.carbon.crypto.provider.hsm/pom.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>carbon-crypto-provider-hsm</artifactId>
+        <groupId>org.wso2.carbon.crypto</groupId>
+        <version>1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.crypto.provider.hsm</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 - HSM Based Crypto Provider</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.crypto</groupId>
+            <artifactId>org.wso2.carbon.crypto.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.pkcs11</groupId>
+            <artifactId>org.wso2.carbon.pkcs11.wrapper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.base</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>${maven.scr.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <obrRepository>NONE</obrRepository>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Private-Package>org.wso2.carbon.crypto.provider.hsm.internal</Private-Package>
+                        <Import-Package>
+                            org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+                            org.apache.commons.lang; version="${commons-lang.version.range}",
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            iaik.pkcs.pkcs11.*; version="${pkcs11.wrapper.imp.pkg.version.range}",
+                            org.wso2.carbon.base.api; version="${carbon.base.osgi.version.range}",
+                            org.wso2.carbon.core; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.crypto.api; version="${carbon.crypto.api.imp.pkg.version.range}",
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.crypto.provider.hsm.internal,
+                            org.wso2.carbon.crypto.provider.hsm.cryptoprovider; version="${project.version}",
+                            org.wso2.carbon.crypto.provider.hsm.*; version="${project.version}",
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/java/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                    <reuseForks>true</reuseForks>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/lib/*</exclude>
+                        <exclude>**/internal/*</exclude>
+                        <exclude>**/exception/*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-instrument</id>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!--<minimum>0.60</minimum>-->
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/DefaultSlotResolver.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/DefaultSlotResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoContext;
+
+/**
+ * This is the {@link SlotResolver} default implementation.
+ */
+public class DefaultSlotResolver implements SlotResolver {
+
+    private static final String EXTERNAL_PROVIDER_SLOT_PROPERTY_PATH =
+            "CryptoService.HSMBasedCryptoProviderConfig.ExternalProvider.ExternalProviderSlotID";
+
+    private static Log log = LogFactory.getLog(DefaultSlotResolver.class);
+
+    private ServerConfigurationService serverConfigurationService;
+
+    /**
+     * Constructor of {@link DefaultSlotResolver}.
+     *
+     * @param serverConfigurationService : carbon.xml configuration reading service.
+     */
+    public DefaultSlotResolver(ServerConfigurationService serverConfigurationService) {
+
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    /**
+     * This is a simple {@link SlotResolver} implementation based on there are two different slots configured for
+     * InternalCryptoProvider and ExternalCryptoProvider.
+     *
+     * @param cryptoContext : Context information related to the given cryptographic operation.
+     * @return {@link SlotInfo}
+     */
+    @Override
+    public SlotInfo resolveSlot(CryptoContext cryptoContext) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Resolving slot in HSM device related to crypto context : %s.", cryptoContext));
+        }
+        return new SlotInfo(Integer.parseInt(serverConfigurationService
+                .getFirstProperty(EXTERNAL_PROVIDER_SLOT_PROPERTY_PATH)), null);
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedExternalCryptoProvider.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedExternalCryptoProvider.java
@@ -1,0 +1,606 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.AESSecretKey;
+import iaik.pkcs.pkcs11.objects.Certificate;
+import iaik.pkcs.pkcs11.objects.DES2SecretKey;
+import iaik.pkcs.pkcs11.objects.DES3SecretKey;
+import iaik.pkcs.pkcs11.objects.DESSecretKey;
+import iaik.pkcs.pkcs11.objects.Key;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+import iaik.pkcs.pkcs11.objects.SecretKey;
+import iaik.pkcs.pkcs11.parameters.GcmParameters;
+import iaik.pkcs.pkcs11.parameters.InitializationVectorParameters;
+import iaik.pkcs.pkcs11.parameters.Parameters;
+import iaik.pkcs.pkcs11.wrapper.CK_GCM_PARAMS;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CertificateInfo;
+import org.wso2.carbon.crypto.api.CryptoContext;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.api.ExternalCryptoProvider;
+import org.wso2.carbon.crypto.api.HybridEncryptionInput;
+import org.wso2.carbon.crypto.api.HybridEncryptionOutput;
+import org.wso2.carbon.crypto.api.PrivateKeyInfo;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.CertificateHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators.Cipher;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators.SignatureHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.KeyTemplateGenerator;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismDataHolder;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolver;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.DECRYPT_MODE;
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.ENCRYPT_MODE;
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.SIGN_MODE;
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.VERIFY_MODE;
+
+/**
+ * Implementation of {@link ExternalCryptoProvider} to provide cryptographic operations using Hardware Security Modules.
+ */
+public class HSMBasedExternalCryptoProvider implements ExternalCryptoProvider {
+
+    private static Log log = LogFactory.getLog(HSMBasedExternalCryptoProvider.class);
+
+    private SessionHandler sessionHandler;
+    private MechanismResolver mechanismResolver;
+    private SlotResolver slotResolver;
+
+    /**
+     * Constructor of {@link HSMBasedExternalCryptoProvider}.
+     * Sets default {@link SessionHandler}, {@link MechanismResolver} for External provider.
+     *
+     * @param serverConfigurationService : carbon.xml configuration is provided using this service.
+     * @throws CryptoException If something unexpected happens during instantiating the External Crypto Provider.
+     */
+    public HSMBasedExternalCryptoProvider(ServerConfigurationService serverConfigurationService)
+            throws CryptoException {
+
+        sessionHandler = SessionHandler.getDefaultSessionHandler(serverConfigurationService);
+        mechanismResolver = MechanismResolver.getInstance();
+        slotResolver = new DefaultSlotResolver(serverConfigurationService);
+    }
+
+    /**
+     * Computes and returns the signature of given data, using the underlying HSM device.
+     * Private key is retrieved from the HSM device.
+     *
+     * @param data                    The data whose signature is calculated.
+     * @param algorithm               The signature + hashing algorithm to be used in signing.
+     * @param javaSecurityAPIProvider The Java Security API provider.
+     * @param cryptoContext           The context information needed for signing.
+     * @param privateKeyInfo          Information about the private key.
+     * @return The signature
+     * @throws CryptoException If something unexpected happens during the signing operation.
+     */
+    @Override
+    public byte[] sign(byte[] data, String algorithm, String javaSecurityAPIProvider, CryptoContext cryptoContext,
+                       PrivateKeyInfo privateKeyInfo) throws CryptoException {
+
+        failIfMethodParametersInvalid(algorithm);
+        logDebug(String.format("Signing data with %s algorithm and %s private key using HSM device.", algorithm,
+                privateKeyInfo.getKeyAlias()));
+        Mechanism signMechanism = mechanismResolver.resolveMechanism(new MechanismDataHolder(SIGN_MODE, algorithm));
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), false);
+        PrivateKey signingKey = retrievePrivateKey(session, privateKeyInfo);
+        SignatureHandler signatureHandler = new SignatureHandler(session);
+        try {
+            return signatureHandler.sign(data, signingKey, signMechanism);
+        } finally {
+            logDebug(String.format("Successfully signed data with %s algorithm and %s private key using HSM device.",
+                    algorithm, privateKeyInfo.getKeyAlias()));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    /**
+     * Computes and returns the cleartext of the given cipher text using the underlying HSM device.
+     * Assumes that keys are stored in the underlying HSM device.
+     *
+     * @param ciphertext              The ciphertext to be decrypted.
+     * @param algorithm               The encryption / decryption algorithm
+     * @param javaSecurityAPIProvider The Java Security API provider.
+     * @param cryptoContext           The context information needed for signing.
+     * @param privateKeyInfo          Information about the private key.
+     * @return The cleartext
+     * @throws CryptoException If something unexpected happens during the decryption operation.
+     */
+    @Override
+    public byte[] decrypt(byte[] ciphertext, String algorithm, String javaSecurityAPIProvider,
+                          CryptoContext cryptoContext, PrivateKeyInfo privateKeyInfo) throws CryptoException {
+
+        failIfMethodParametersInvalid(algorithm);
+        logDebug(String.format("Decrypting data with %s algorithm and %s private key using HSM device.",
+                algorithm, privateKeyInfo.getKeyAlias()));
+        Mechanism decryptionMechanism = mechanismResolver.resolveMechanism(
+                new MechanismDataHolder(DECRYPT_MODE, algorithm));
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), false);
+        PrivateKey decryptionKey = retrievePrivateKey(session, privateKeyInfo);
+        Cipher cipher = new Cipher(session);
+        try {
+            return cipher.decrypt(ciphertext, decryptionKey, decryptionMechanism);
+        } finally {
+            logDebug(String.format("Successfully decrypted data with %s algorithm and %s private key using HSM device.",
+                    algorithm, privateKeyInfo.getKeyAlias()));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    /**
+     * Computes and returns the cipher text of the given cleartext using the underlying HSM device.
+     * Public key is retrieved from the underlying HSM device.
+     *
+     * @param data                    The cleartext to be encrypted.
+     * @param algorithm               The signature + hashing algorithm to be used in signing.
+     * @param javaSecurityAPIProvider The Java Security API provider.
+     * @param cryptoContext           The context information which was used to find discovery information about the
+     *                                certificate
+     *                                of the external entity.
+     * @param certificateInfo         The information which is needed to retrieve the certificate.
+     *                                If this information is not sufficient the {@link CryptoContext} will be used to
+     *                                get more information.
+     * @return The cleartext
+     * @throws CryptoException If something unexpected happens during the encryption operation.
+     */
+    @Override
+    public byte[] encrypt(byte[] data, String algorithm, String javaSecurityAPIProvider,
+                          CryptoContext cryptoContext, CertificateInfo certificateInfo) throws CryptoException {
+
+        failIfMethodParametersInvalid(algorithm);
+        logDebug(String.format("Encrypting data with %s algorithm using HSM device with public certificate : %s",
+                algorithm, certificateInfo));
+        Mechanism encryptionMechanism = mechanismResolver.resolveMechanism(
+                new MechanismDataHolder(ENCRYPT_MODE, algorithm));
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), false);
+        PublicKey encryptionKey = retrievePublicKey(session, certificateInfo);
+        Cipher cipher = new Cipher(session);
+        try {
+            return cipher.encrypt(data, encryptionKey, encryptionMechanism);
+        } finally {
+            logDebug(String.format("Successfully encrypted data with %s algorithm using HSM device with public " +
+                    "certificate : %s", algorithm, certificateInfo));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    /**
+     * Verifies whether given signature of the given data was generated by a trusted external party.
+     * Signature verification is carried out using the underlying HSM device.
+     * Public key is retrieved from the HSM device.
+     *
+     * @param data                    The data which was the signature generated on.
+     * @param signature               The signature bytes of data.
+     * @param algorithm               The signature + hashing algorithm to be used in signing.
+     * @param javaSecurityAPIProvider The Java Security API provider.
+     * @param cryptoContext           The context information which is needed to discover the public key of
+     *                                the external entity.
+     * @param certificateInfo         The information which is needed to retrieve the certificate.
+     *                                If this information is not sufficient the {@link CryptoContext} will be used to
+     *                                get more information.
+     * @return true if signature can be verified, false otherwise.
+     * @throws CryptoException If something unexpected happens during the signature verification.
+     */
+    @Override
+    public boolean verifySignature(byte[] data, byte[] signature, String algorithm, String javaSecurityAPIProvider,
+                                   CryptoContext cryptoContext, CertificateInfo certificateInfo) throws CryptoException {
+
+        failIfMethodParametersInvalid(algorithm);
+        logDebug(String.format("Verifying digital signature with %s algorithm using the HSM device with public " +
+                "certificate : %s", algorithm, certificateInfo));
+        Mechanism verifyMechanism = mechanismResolver.resolveMechanism(new MechanismDataHolder(VERIFY_MODE, algorithm));
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), false);
+        PublicKey verificationKey = retrievePublicKey(session, certificateInfo);
+        SignatureHandler signatureHandler = new SignatureHandler(session);
+        try {
+            return signatureHandler.verify(data, signature, verificationKey, verifyMechanism);
+        } finally {
+            logDebug(String.format("Successfully verified digital signature with %s algorithm using the HSM device " +
+                    "with public certificate : %s", algorithm, certificateInfo));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    /**
+     * Returns the {@link java.security.cert.Certificate} based on the given {@link CryptoContext}
+     * Certificate is retrieved from the underlying HSM device.
+     *
+     * @param cryptoContext   The context information which is used to discover the public key of the external entity.
+     * @param certificateInfo The information which is needed to retrieve the certificate.
+     *                        If this information is not sufficient the {@link CryptoContext} will be used to
+     *                        get more information.
+     * @return The {@link java.security.cert.Certificate} relates with the given context.
+     * @throws CryptoException If something unexpected happens during certificate discovery.
+     */
+    @Override
+    public java.security.cert.Certificate getCertificate(CryptoContext cryptoContext,
+                                                         CertificateInfo certificateInfo) throws CryptoException {
+
+        failIfContextInformationIsMissing(cryptoContext);
+        logDebug(String.format("Retrieving certificate with alias %s related to crypto context : '%s' " +
+                "from the HSM device.", certificateInfo.getCertificateAlias(), cryptoContext));
+        Certificate retrievedCertificate = retrieveCertificate(certificateInfo.getCertificateAlias(), cryptoContext);
+        return PKCS11JCEObjectMapper.mapCertificatePKCS11ToJCE(retrievedCertificate);
+    }
+
+    /**
+     * Returns the {@link java.security.PrivateKey} based on the given {@link CryptoContext}
+     * This certificate is retrieved from the underlying HSM device.
+     * This implementation supports only RSA private keys at the moment.
+     *
+     * @param cryptoContext  The context information which is used to discover the applicable private key.
+     * @param privateKeyInfo The information which is needed to retrieve the private key.
+     *                       If this information is not sufficient, the {@link CryptoContext} will be used to
+     *                       get more information.
+     * @return The {@link java.security.PrivateKey} relates with the given context.
+     * @throws CryptoException If something unexpected happens during private key discovery.
+     */
+    @Override
+    public java.security.PrivateKey getPrivateKey(CryptoContext cryptoContext,
+                                                  PrivateKeyInfo privateKeyInfo) throws CryptoException {
+
+        failIfContextInformationIsMissing(cryptoContext);
+        logDebug(String.format("Retrieving %s private key related crypto context : '%s' from HSM device",
+                privateKeyInfo.getKeyAlias(), cryptoContext));
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), false);
+        PrivateKey retrievedKey;
+        try {
+            retrievedKey = retrievePrivateKey(session, privateKeyInfo);
+        } finally {
+            sessionHandler.closeSession(session);
+        }
+        if (!retrievedKey.getSensitive().getBooleanValue() && retrievedKey.getExtractable().getBooleanValue()) {
+            return PKCS11JCEObjectMapper.mapPrivateKeyPKCS11ToJCE(retrievedKey);
+        } else {
+            String errorMessage = String.format("Requested private key %s is not extractable.",
+                    privateKeyInfo.getKeyAlias());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    /**
+     * Computes and returns the {@link HybridEncryptionOutput} based on provided {@link HybridEncryptionInput}
+     * Hybrid encryption is carried out using the underlying HSM device.
+     * Session object is created for symmetric key for decryption.
+     *
+     * @param hybridEncryptionInput Input data for hybrid encryption.*
+     * @param symmetricAlgorithm    The symmetric encryption/decryption algorithm.
+     * @param asymmetricAlgorithm   The asymmetric encryption/decryption algorithm.
+     * @param javaSecurityProvider  The Java Security API provider. This value is discarded in this component.
+     * @param cryptoContext         The context information which is used to discover
+     *                              the public key of the external entity.
+     * @return {@link HybridEncryptionOutput} cipher text with required parameters
+     * @throws CryptoException
+     */
+    @Override
+    public HybridEncryptionOutput hybridEncrypt(HybridEncryptionInput hybridEncryptionInput, String symmetricAlgorithm,
+                                                String asymmetricAlgorithm, String javaSecurityProvider,
+                                                CryptoContext cryptoContext, CertificateInfo certificateInfo)
+            throws CryptoException {
+
+        logDebug(String.format("Hybrid encrypting data with %s symmetric algorithm and %s asymmetric algorithm, " +
+                "using HSM device with certificate : %s.", symmetricAlgorithm, asymmetricAlgorithm, certificateInfo));
+        MechanismDataHolder mechanismDataHolder = new MechanismDataHolder(ENCRYPT_MODE, symmetricAlgorithm,
+                hybridEncryptionInput.getAuthData());
+        Mechanism symmetricMechanism = mechanismResolver.resolveMechanism(mechanismDataHolder);
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), true);
+        //Retrieving symmetric key for symmetric encryption.
+        SecretKey encryptionKey = getSymmetricKey(session, symmetricAlgorithm, null, true);
+        byte[] encryptedData = symmetricEncrypt(session, symmetricMechanism, encryptionKey,
+                hybridEncryptionInput.getPlainData());
+        logDebug(String.format("Successfully encrypted the plain data with %s symmetric algorithm and %s symmetric " +
+                "key.", symmetricAlgorithm, encryptionKey.getClass().getName()));
+        //Encrypting symmetric key.
+        byte[] encryptedKey = encryptSymmetricKey(encryptionKey, asymmetricAlgorithm, cryptoContext, certificateInfo);
+        logDebug(String.format("Successfully encrypted '%s' symmetric key for hybrid encryption with %s asymmetric " +
+                        "algorithm and public certificate : %s", encryptionKey.getClass().getName(),
+                asymmetricAlgorithm, certificateInfo));
+        //Generating output of the hybrid encryption.
+        HybridEncryptionOutput hybridEncryptionOutput = generateHybridEncryptionOutput(symmetricMechanism,
+                encryptedData, encryptedKey);
+        logDebug(String.format("Successfully hybrid encrypted data with %s symmetric algorithm and %s asymmetric " +
+                        "algorithm, using HSM device with certificate : %s.", symmetricAlgorithm,
+                asymmetricAlgorithm, certificateInfo));
+        return hybridEncryptionOutput;
+    }
+
+    /**
+     * Computes and return clear data based on provided {@link HybridEncryptionOutput}
+     * Hybrid decryption is carried out using the underlying HSM device.
+     * Session object is created for symmetric key for decryption.
+     *
+     * @param hybridDecryptionInput {@link HybridEncryptionOutput} ciphered data with parameters.
+     * @param symmetricAlgorithm    The symmetric encryption/decryption algorithm.
+     * @param asymmetricAlgorithm   The asymmetric encryption/decryption algorithm.
+     * @param javaSecurityProvider  The Java Security API provider.
+     * @param cryptoContext         The context information which is used to discover
+     *                              the public key of the external entity.
+     * @return the decrypted data
+     * @throws CryptoException
+     */
+    @Override
+    public byte[] hybridDecrypt(HybridEncryptionOutput hybridDecryptionInput, String symmetricAlgorithm,
+                                String asymmetricAlgorithm, String javaSecurityProvider, CryptoContext cryptoContext,
+                                PrivateKeyInfo privateKeyInfo) throws CryptoException {
+
+        logDebug(String.format("Hybrid decrypting data with %s symmetric algorithm and %s asymmetric algorithm, " +
+                        "using HSM device with private key %s.", symmetricAlgorithm, asymmetricAlgorithm,
+                privateKeyInfo.getKeyAlias()));
+        //Decrypting symmetric key value used for data encryption.
+        byte[] decryptionKeyValue = decrypt(hybridDecryptionInput.getEncryptedSymmetricKey(), asymmetricAlgorithm,
+                javaSecurityProvider, cryptoContext, privateKeyInfo);
+        logDebug(String.format("Successfully decrypted the value of symmetric key used for hybrid encryption."));
+        MechanismDataHolder mechanismDataHolder = new MechanismDataHolder(DECRYPT_MODE, symmetricAlgorithm,
+                hybridDecryptionInput.getParameterSpec(), hybridDecryptionInput.getAuthData());
+        Mechanism decryptionMechanism = mechanismResolver.resolveMechanism(mechanismDataHolder);
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), true);
+        try {
+            //Generating a symmetric key with given value, for data decryption.
+            SecretKey decryptionKey = getSymmetricKey(session, symmetricAlgorithm, decryptionKeyValue, false);
+            Cipher cipher = new Cipher(session);
+            if (hybridDecryptionInput.getAuthTag() != null) {
+                byte[] encryptedData = concatByteArrays(new byte[][]{hybridDecryptionInput.getCipherData(),
+                        hybridDecryptionInput.getAuthTag()});
+                return cipher.decrypt(encryptedData, decryptionKey, decryptionMechanism);
+            } else {
+                return cipher.decrypt(hybridDecryptionInput.getCipherData(), decryptionKey, decryptionMechanism);
+            }
+        } finally {
+            logDebug(String.format("Successfully hybrid decrypted data with %s symmetric algorithm and %s asymmetric" +
+                            " algorithm, using HSM device with private key %s.", symmetricAlgorithm,
+                    asymmetricAlgorithm, privateKeyInfo.getKeyAlias()));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    protected byte[] symmetricEncrypt(Session session, Mechanism symmetricAlgorithm, Key encryptionKey,
+                                      byte[] plainData) throws CryptoException {
+
+        try {
+            Cipher cipher = new Cipher(session);
+            return cipher.encrypt(plainData, encryptionKey, symmetricAlgorithm);
+        } finally {
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    protected Session initiateSession(SlotInfo slotInfo, boolean readWrite) throws CryptoException {
+
+        return sessionHandler.initiateSession(slotInfo.getSlotID(), slotInfo.getPin(), readWrite);
+    }
+
+    protected void failIfContextInformationIsMissing(CryptoContext cryptoContext) throws CryptoException {
+
+        if (cryptoContext == null || cryptoContext.getTenantId() == 0 ||
+                StringUtils.isBlank(cryptoContext.getTenantDomain())) {
+            throw new CryptoException("Tenant information is missing in the crypto context.");
+        }
+    }
+
+    protected void failIfMethodParametersInvalid(String algorithm) throws CryptoException {
+
+        if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+            String errorMessage = String.format("Requested algorithm '%s' is not valid/supported.", algorithm);
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected PublicKey retrievePublicKey(Session session, CertificateInfo certificateInfo) throws CryptoException {
+
+        logDebug(String.format("Retrieving public key from certificate with alias %s",
+                certificateInfo.getCertificateAlias()));
+        if (certificateInfo.getCertificate() != null) {
+            java.security.PublicKey publicKey = certificateInfo.getCertificate().getPublicKey();
+            if (!(publicKey instanceof java.security.interfaces.RSAPublicKey)) {
+                throw new CryptoException("HSM based crypto provider supports only for RSA public key session objects.");
+            }
+            PKCS11CertificateData certificateData = PKCS11JCEObjectMapper
+                    .mapCertificateJCEToPKCS11(certificateInfo.getCertificate());
+            certificateData.getPublicKey().getLabel().setCharArrayValue("RSA".toCharArray());
+            return retrieveKeyHandle(session, certificateData.getPublicKey());
+        } else {
+            PublicKey publicKeyTemplate = new PublicKey();
+            publicKeyTemplate.getLabel().setCharArrayValue(certificateInfo.getCertificateAlias().toCharArray());
+            publicKeyTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_PUBLIC_KEY);
+            return (PublicKey) retrieveKey(publicKeyTemplate, session);
+        }
+    }
+
+    protected PublicKey retrieveKeyHandle(Session session, PublicKey publicKey) throws HSMCryptoException {
+
+        KeyHandler keyHandler = new KeyHandler(session);
+        return (PublicKey) keyHandler.getKeyHandle(publicKey);
+    }
+
+    protected PrivateKey retrievePrivateKey(Session session, PrivateKeyInfo privateKeyInfo) throws CryptoException {
+
+        logDebug(String.format("Retrieving private key with alias '%s' from HSM device.",
+                privateKeyInfo.getKeyAlias()));
+        PrivateKey privateKeyTemplate = new PrivateKey();
+        privateKeyTemplate.getLabel().setCharArrayValue(privateKeyInfo.getKeyAlias().toCharArray());
+        privateKeyTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_PRIVATE_KEY);
+        return (PrivateKey) retrieveKey(privateKeyTemplate, session);
+    }
+
+    protected Key retrieveKey(Key keyTemplate, Session session) throws CryptoException {
+
+        KeyHandler keyHandler = new KeyHandler(session);
+        return keyHandler.retrieveKey(keyTemplate);
+    }
+
+    protected Certificate retrieveCertificate(String label, CryptoContext cryptoContext) throws CryptoException {
+
+        Certificate certificateTemplate = new Certificate();
+        certificateTemplate.getLabel().setCharArrayValue(label.toCharArray());
+        certificateTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_CERTIFICATE);
+        Session session = initiateSession(slotResolver.resolveSlot(cryptoContext), false);
+        CertificateHandler certificateHandler = new CertificateHandler(session);
+        try {
+            return certificateHandler.getCertificate(certificateTemplate);
+        } finally {
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    protected SecretKey getSymmetricKey(Session session, String algorithm, byte[] value,
+                                        boolean encryptMode) throws CryptoException {
+
+        String[] keySpecification = algorithm.split("/")[0].split("_");
+        String keyType = keySpecification[0];
+        String errorMessage = String.format("Requested key type generation is not supported for '%s' " +
+                "algorithm", algorithm);
+        SecretKey secretKeyTemplate;
+        if (encryptMode) {
+            if (keyType.equals("AES")) {
+                long keyLength = 32L;
+                if (keySpecification.length > 1) {
+                    keyLength = Long.parseLong(keySpecification[1]) / 8;
+                }
+                secretKeyTemplate = KeyTemplateGenerator.generateAESKeyTemplate();
+                ((AESSecretKey) secretKeyTemplate).getValueLen().setLongValue(keyLength);
+            } else if (keyType.equals("DES")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateDESKeyTemplate();
+            } else if (keyType.equals("DES2")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateDES2KeyTemplate();
+            } else if (keyType.equals("3DES") || keyType.equals("DESede")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateDES3KeyTemplate();
+            } else {
+                throw new CryptoException(errorMessage);
+            }
+        } else {
+            if (keyType.equals("AES")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateAESKeyTemplate();
+                ((AESSecretKey) secretKeyTemplate).getValue().setValue(value);
+            } else if (keyType.equals("DES")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateDESKeyTemplate();
+                ((DESSecretKey) secretKeyTemplate).getValue().setValue(value);
+            } else if (keyType.equals("DES2")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateDES2KeyTemplate();
+                ((DES2SecretKey) secretKeyTemplate).getValue().setValue(value);
+            } else if (keyType.equals("3DES") || keyType.equals("DESede")) {
+                secretKeyTemplate = KeyTemplateGenerator.generateDES3KeyTemplate();
+                ((DES3SecretKey) secretKeyTemplate).getValue().setValue(value);
+            } else {
+                throw new CryptoException(errorMessage);
+            }
+        }
+        return generateKey(secretKeyTemplate, encryptMode, keyType, session);
+    }
+
+    protected SecretKey generateKey(SecretKey secretKeyTemplate, boolean encryptMode, String keyGenAlgo, Session
+            session) throws CryptoException {
+
+        KeyHandler keyHandler = new KeyHandler(session);
+        if (encryptMode) {
+            return keyHandler.generateSecretKey(secretKeyTemplate, mechanismResolver.resolveMechanism(
+                    new MechanismDataHolder(ENCRYPT_MODE, keyGenAlgo)));
+        } else {
+            return (SecretKey) keyHandler.getKeyHandle(secretKeyTemplate);
+        }
+    }
+
+    protected HybridEncryptionOutput generateHybridEncryptionOutput(Mechanism symmetricMechanism, byte[] encryptedData,
+                                                                    byte[] encryptedKey) throws CryptoException {
+
+        Parameters paramObject = symmetricMechanism.getParameters();
+        if (paramObject instanceof GcmParameters) {
+            CK_GCM_PARAMS gcmParams = (CK_GCM_PARAMS) paramObject.getPKCS11ParamsObject();
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec((int) gcmParams.ulTagBits, gcmParams.pIv);
+            int tagPos = encryptedData.length - (int) (gcmParams.ulTagBits) / 8;
+            byte[] cipherData = subArray(encryptedData, 0, tagPos);
+            byte[] authTag = subArray(encryptedData, tagPos, (int) (gcmParams.ulTagBits) / 8);
+            return new HybridEncryptionOutput(cipherData, encryptedKey, gcmParams.pAAD,
+                    authTag, gcmParameterSpec);
+        } else if (paramObject instanceof InitializationVectorParameters) {
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(((InitializationVectorParameters)
+                    paramObject).getInitializationVector());
+            return new HybridEncryptionOutput(encryptedData, encryptedKey, ivParameterSpec);
+        } else {
+            String errorMessage = String.format("Invalid / Unsupported parameter specification for '%s' symmetric " +
+                    "encryption algorithm.", symmetricMechanism.getName());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected byte[] encryptSymmetricKey(SecretKey encryptionKey, String asymmetricAlgorithm, CryptoContext cryptoContext,
+                                         CertificateInfo certificateInfo) throws CryptoException {
+
+        logDebug(String.format("Encrypting generated '%s' symmetric key for hybrid encryption with %s asymmetric " +
+                        "algorithm and public certificate : %s", encryptionKey.getClass().getName(),
+                asymmetricAlgorithm, certificateInfo));
+        if (encryptionKey instanceof AESSecretKey) {
+            return encrypt(((AESSecretKey) encryptionKey).getValue().getByteArrayValue(),
+                    asymmetricAlgorithm, null, cryptoContext, certificateInfo);
+        } else if (encryptionKey instanceof DESSecretKey) {
+            return encrypt(((DESSecretKey) encryptionKey).getValue().getByteArrayValue(),
+                    asymmetricAlgorithm, null, cryptoContext, certificateInfo);
+        } else if (encryptionKey instanceof DES2SecretKey) {
+            return encrypt(((DES2SecretKey) encryptionKey).getValue().getByteArrayValue(),
+                    asymmetricAlgorithm, null, cryptoContext, certificateInfo);
+        } else if (encryptionKey instanceof DES3SecretKey) {
+            return encrypt(((DES3SecretKey) encryptionKey).getValue().getByteArrayValue(),
+                    asymmetricAlgorithm, null, cryptoContext, certificateInfo);
+        } else {
+            String errorMessage = String.format("Symmetric encryption key instance '%s' provided for hybrid " +
+                    "encryption is not supported by the provider", encryptionKey.getClass().getName());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected byte[] subArray(byte[] byteArray, int beginIndex, int length) {
+
+        byte[] subArray = new byte[length];
+        System.arraycopy(byteArray, beginIndex, subArray, 0, subArray.length);
+        return subArray;
+    }
+
+    protected byte[] concatByteArrays(byte[][] byteArrays) throws CryptoException {
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        for (byte[] byteArray : byteArrays) {
+            try {
+                outputStream.write(byteArray);
+            } catch (IOException e) {
+                String errorMessage = String.format("Error occurred while decrypting hybrid encrypted data.");
+                throw new CryptoException(errorMessage, e);
+            }
+        }
+        return outputStream.toByteArray();
+    }
+
+    protected void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedInternalCryptoProvider.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedInternalCryptoProvider.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.Key;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.api.InternalCryptoProvider;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators.Cipher;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismDataHolder;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolver;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.DECRYPT_MODE;
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.ENCRYPT_MODE;
+
+/**
+ * Implementation of {@link InternalCryptoProvider} to provide cryptographic operations using Hardware Security Modules.
+ */
+public class HSMBasedInternalCryptoProvider implements InternalCryptoProvider {
+
+    private static final String INTERNAL_PROVIDER_SLOT_PROPERTY_PATH =
+            "CryptoService.HSMBasedCryptoProviderConfig.InternalProvider.InternalProviderSlotID";
+    private static final String HSM_BASED_INTERNAL_PROVIDER_KEY_ALIAS_PATH =
+            "CryptoService.HSMBasedCryptoProviderConfig.InternalProvider.KeyAlias";
+
+    private static Log log = LogFactory.getLog(HSMBasedInternalCryptoProvider.class);
+
+    private String keyAlias;
+    private SessionHandler sessionHandler;
+    private MechanismResolver mechanismResolver;
+    private ServerConfigurationService serverConfigurationService;
+
+    /**
+     * Constructor of HSMBasedInternalCryptoProvider. This is an asymmetric crypto provider which caters
+     * internal cryptographic requirements using underlying HSM.
+     *
+     * @param serverConfigurationService : carbon.xml data as a configuration service.
+     */
+    public HSMBasedInternalCryptoProvider(ServerConfigurationService serverConfigurationService)
+            throws CryptoException {
+
+        this.keyAlias = serverConfigurationService.getFirstProperty(HSM_BASED_INTERNAL_PROVIDER_KEY_ALIAS_PATH);
+        if (StringUtils.isBlank(keyAlias)) {
+            throw new CryptoException("Key/Certificate aliases provided for internal crypto provider can't be empty.");
+        }
+        sessionHandler = SessionHandler.getDefaultSessionHandler(serverConfigurationService);
+        mechanismResolver = MechanismResolver.getInstance();
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    /**
+     * Computes and returns the ciphertext of the given cleartext, using the underlying HSM device.
+     *
+     * @param cleartext               The cleartext to be encrypted.
+     * @param algorithm               The encryption / decryption algorithm
+     * @param javaSecurityAPIProvider The JCE provider used for encryption. For this implementation JCE provider
+     *                                is discarded.
+     * @return the ciphertext
+     * @throws CryptoException
+     */
+    @Override
+    public byte[] encrypt(byte[] cleartext, String algorithm, String javaSecurityAPIProvider) throws CryptoException {
+
+        failIfMethodParametersInvalid(algorithm, cleartext);
+        logDebug(String.format("Encrypting data with %s algorithm using HSM device with %s public key.",
+                algorithm, keyAlias));
+        PublicKey publicKeyTemplate = new PublicKey();
+        publicKeyTemplate.getLabel().setCharArrayValue(keyAlias.toCharArray());
+        publicKeyTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_PUBLIC_KEY);
+        Mechanism encryptionMechanism = mechanismResolver.resolveMechanism(
+                new MechanismDataHolder(ENCRYPT_MODE, algorithm));
+        Session session = initiateSession(getInternalProviderSlotInfo());
+        PublicKey encryptionKey = (PublicKey) retrieveKey(publicKeyTemplate, session);
+        Cipher cipher = new Cipher(session);
+        try {
+            return cipher.encrypt(cleartext, encryptionKey, encryptionMechanism);
+        } finally {
+            logDebug(String.format("Successfully encrypted data with %s algorithm using HSM device with %s public " +
+                    "key", algorithm, keyAlias));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    /**
+     * Computes and returns the cleartext of the given ciphertext, using the underlying HSM device.
+     *
+     * @param ciphertext              The ciphertext to be decrypted.
+     * @param algorithm               The encryption / decryption algorithm
+     * @param javaSecurityAPIProvider The JCE provider used for decryption. For this implementation JCE provider
+     *                                is discarded.
+     * @return The cleartext
+     * @throws CryptoException If something unexpected happens during the decryption operation.
+     */
+    @Override
+    public byte[] decrypt(byte[] ciphertext, String algorithm, String javaSecurityAPIProvider) throws CryptoException {
+
+        failIfMethodParametersInvalid(algorithm, ciphertext);
+        logDebug(String.format("Decrypting data with %s algorithm and %s private key using HSM device.",
+                algorithm, keyAlias));
+        PrivateKey privateKeyTemplate = new PrivateKey();
+        privateKeyTemplate.getLabel().setCharArrayValue(keyAlias.toCharArray());
+        privateKeyTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_PRIVATE_KEY);
+        Mechanism decryptionMechanism = mechanismResolver.resolveMechanism(
+                new MechanismDataHolder(DECRYPT_MODE, algorithm));
+        Session session = initiateSession(getInternalProviderSlotInfo());
+        PrivateKey decryptionKey = (PrivateKey) retrieveKey(privateKeyTemplate, session);
+        Cipher cipher = new Cipher(session);
+        try {
+            return cipher.decrypt(ciphertext, decryptionKey, decryptionMechanism);
+        } finally {
+            logDebug(String.format("Successfully decrypted data with %s algorithm and %s private key using HSM device.",
+                    algorithm, keyAlias));
+            sessionHandler.closeSession(session);
+        }
+    }
+
+    protected Session initiateSession(SlotInfo slotInfo) throws CryptoException {
+
+        return sessionHandler.initiateSession(slotInfo.getSlotID(), slotInfo.getPin(), false);
+    }
+
+    protected void failIfMethodParametersInvalid(String algorithm, byte[] data)
+            throws CryptoException {
+
+        if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+            String errorMessage = String.format("Requested algorithm '%s' is not valid/supported by the " +
+                    "HSM based Crypto Provider.", algorithm);
+            throw new CryptoException(errorMessage);
+        }
+
+        if (data == null || data.length == 0) {
+            String errorMessage = "Data sent for cryptographic operation is null/empty.";
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected Key retrieveKey(Key keyTemplate, Session session) throws CryptoException {
+
+        logDebug(String.format("Retrieving key with alias %s from the HSM device.",
+                new String(keyTemplate.getLabel().getCharArrayValue())));
+        KeyHandler keyHandler = new KeyHandler(session);
+        return keyHandler.retrieveKey(keyTemplate);
+    }
+
+    protected void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+
+    protected SlotInfo getInternalProviderSlotInfo() {
+
+        return new SlotInfo(Integer.parseInt(serverConfigurationService
+                .getFirstProperty(INTERNAL_PROVIDER_SLOT_PROPERTY_PATH)), null);
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedKeyResolver.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedKeyResolver.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.core.RegistryResources;
+import org.wso2.carbon.crypto.api.CertificateInfo;
+import org.wso2.carbon.crypto.api.CryptoContext;
+import org.wso2.carbon.crypto.api.KeyResolver;
+import org.wso2.carbon.crypto.api.PrivateKeyInfo;
+
+import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
+
+/**
+ * Implementation of {@link KeyResolver} to resolve keys and certificates from the HSM.
+ */
+public class HSMBasedKeyResolver extends KeyResolver {
+
+    private static Log log = LogFactory.getLog(HSMBasedKeyResolver.class);
+
+    private ServerConfigurationService serverConfigurationService;
+
+    /**
+     * Constructor of HSM based key resolver.
+     *
+     * @param serverConfigurationService : carbon.xml configuration is provided using this service.
+     */
+    public HSMBasedKeyResolver(ServerConfigurationService serverConfigurationService) {
+
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    /**
+     * Checks if the given context can be resolved by this Key Resolver.
+     *
+     * @param cryptoContext Context information related to the cryptographic operation.
+     * @return Return whether this resolver is applicable for the context.
+     */
+    @Override
+    public boolean isApplicable(CryptoContext cryptoContext) {
+
+        return true;
+    }
+
+    /**
+     * Returns private key information related to given {@link CryptoContext}.
+     *
+     * @param cryptoContext Context information related to the cryptographic operation.
+     * @return {@link PrivateKeyInfo} related to given context information.
+     */
+    @Override
+    public PrivateKeyInfo getPrivateKeyInfo(CryptoContext cryptoContext) {
+
+        String keyAlias;
+        String keyPassword;
+        if (SUPER_TENANT_ID == cryptoContext.getTenantId()) {
+            keyAlias = serverConfigurationService.getFirstProperty(RegistryResources.SecurityManagement
+                    .SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
+        } else {
+            keyAlias = cryptoContext.getTenantDomain();
+            keyPassword = null; // Key password will be internally handled by the KeyStoreManager
+        }
+        logDebug(String.format("Successfully resolved private key information related to crypto context : %s",
+                cryptoContext));
+        return new PrivateKeyInfo(keyAlias, null);
+    }
+
+    /**
+     * Returns certificate information related to given {@link CryptoContext}.
+     *
+     * @param cryptoContext : Context information related to the cryptographic operation.
+     * @return {@link CertificateInfo} related to given context information.
+     */
+    @Override
+    public CertificateInfo getCertificateInfo(CryptoContext cryptoContext) {
+
+        String certificateAlias;
+        if (SUPER_TENANT_ID == cryptoContext.getTenantId()) {
+            certificateAlias = serverConfigurationService.getFirstProperty(RegistryResources.SecurityManagement
+                    .SERVER_PRIMARY_KEYSTORE_KEY_ALIAS);
+        } else {
+            certificateAlias = cryptoContext.getTenantDomain();
+        }
+        logDebug(String.format("Successfully resolved certificate information related to crypto context : %s",
+                cryptoContext));
+        return new CertificateInfo(certificateAlias, null);
+    }
+
+    protected void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedKeyResolver.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedKeyResolver.java
@@ -78,8 +78,10 @@ public class HSMBasedKeyResolver extends KeyResolver {
             keyAlias = cryptoContext.getTenantDomain();
             keyPassword = null; // Key password will be internally handled by the KeyStoreManager
         }
-        logDebug(String.format("Successfully resolved private key information related to crypto context : %s",
-                cryptoContext));
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Successfully resolved private key information related to crypto context : %s",
+                    cryptoContext));
+        }
         return new PrivateKeyInfo(keyAlias, null);
     }
 
@@ -99,15 +101,10 @@ public class HSMBasedKeyResolver extends KeyResolver {
         } else {
             certificateAlias = cryptoContext.getTenantDomain();
         }
-        logDebug(String.format("Successfully resolved certificate information related to crypto context : %s",
-                cryptoContext));
-        return new CertificateInfo(certificateAlias, null);
-    }
-
-    protected void logDebug(String message) {
-
         if (log.isDebugEnabled()) {
-            log.debug(message);
+            log.debug(String.format("Successfully resolved certificate information related to crypto context : %s",
+                    cryptoContext));
         }
+        return new CertificateInfo(certificateAlias, null);
     }
 }

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/PKCS11CertificateData.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/PKCS11CertificateData.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import iaik.pkcs.pkcs11.objects.Certificate;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+
+/**
+ * Instance of this class holds {@link Certificate} and {@link PublicKey} of the PKCS11 certificates.
+ */
+public class PKCS11CertificateData {
+
+    private Certificate certificate;
+    private PublicKey publicKey;
+
+    /**
+     * Constructor of {@link PKCS11CertificateData}.
+     *
+     * @param certificate :Public key certificate.
+     * @param publicKey   :Public key.
+     */
+    public PKCS11CertificateData(Certificate certificate, PublicKey publicKey) {
+
+        this.certificate = certificate;
+        this.publicKey = publicKey;
+    }
+
+    public Certificate getCertificate() {
+
+        return certificate;
+    }
+
+    public PublicKey getPublicKey() {
+
+        return publicKey;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/PKCS11JCEObjectMapper.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/PKCS11JCEObjectMapper.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import iaik.pkcs.pkcs11.objects.Certificate;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.RSAPrivateKey;
+import iaik.pkcs.pkcs11.objects.RSAPublicKey;
+import iaik.pkcs.pkcs11.objects.X509PublicKeyCertificate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.crypto.api.CryptoException;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPrivateKeySpec;
+
+/**
+ * This class maps PKCS 11 certificates and private keys to JCE certificates and private keys and vice versa.
+ */
+public class PKCS11JCEObjectMapper {
+
+    private static Log log = LogFactory.getLog(PKCS11JCEObjectMapper.class);
+
+    /**
+     * This static method maps JCE certificate to PKCS 11 certificate.
+     *
+     * @param certificate : JCE Certificate
+     * @return PKCS11 Certificate data {@link PKCS11CertificateData}.
+     * @throws CryptoException
+     */
+    public static PKCS11CertificateData mapCertificateJCEToPKCS11(java.security.cert.Certificate certificate)
+            throws CryptoException {
+
+        if (!(certificate instanceof X509Certificate)) {
+            String errorMessage = String.format("PKCS11 JCE object mapper doesn't support for conversion of " +
+                    "%s type certificates from JCE to PKCS #11.", certificate.getType());
+            throw new CryptoException(errorMessage);
+        }
+        X509Certificate x509Certificate = (X509Certificate) certificate;
+        X509PublicKeyCertificate cert = mapX509CertJCEToPKCS11(x509Certificate);
+        RSAPublicKey rsaPublicKey = mapRSAPublicKeyJCEToPKCS11(x509Certificate);
+        logDebug("Successfully mapped PKCS #11 X.509 public certificate to JCE X.509 public certificate.");
+        return new PKCS11CertificateData(cert, rsaPublicKey);
+    }
+
+    /**
+     * This static method maps PKCS 11 certificate to JCE certificate.
+     *
+     * @param certificate : PKCS11 certificate.
+     * @return JCE certificate {@link java.security.cert.Certificate}.
+     * @throws CryptoException
+     */
+    public static java.security.cert.Certificate mapCertificatePKCS11ToJCE(Certificate certificate)
+            throws CryptoException {
+
+        if (!(certificate instanceof X509PublicKeyCertificate)) {
+            String errorMessage = String.format("PKCS11 JCE object mapper doesn't support for conversion of " +
+                    "%s type certificates from PKCS #11 to JCE.", certificate.getClass());
+            throw new CryptoException(errorMessage);
+        }
+        logDebug("Mapping JCE X.509 public certificate to PKCS #11 X.509 public certificate.");
+        byte[] x509Certificate = ((X509PublicKeyCertificate) certificate).getValue().getByteArrayValue();
+        try {
+            java.security.cert.Certificate generatedCertificate = CertificateFactory.getInstance("X.509")
+                    .generateCertificate(new ByteArrayInputStream(x509Certificate));
+            logDebug("Successfully mapped JCE X.509 public certificate to PKCS #11 X.509 public certificate.");
+            return generatedCertificate;
+        } catch (CertificateException e) {
+            String errorMessage = String.format("Error occurred while generating X.509 certificate from the " +
+                    "retrieved certificate from the HSM.");
+            throw new CryptoException(errorMessage, e);
+        }
+    }
+
+    /**
+     * This static method maps JCE private key to PKCS 11 private key.
+     *
+     * @param privateKey : JCE private key.
+     * @return PKCS 11 private key {@link PrivateKey}.
+     * @throws CryptoException
+     */
+    public static PrivateKey mapPrivateKeyJCEToPKCS11(java.security.PrivateKey privateKey) throws CryptoException {
+
+        if (!(privateKey instanceof java.security.interfaces.RSAPrivateKey)) {
+            String errorMessage = String.format("PKCS11 JCE object mapper doesn't support for conversion of %s type " +
+                    "private keys from JCE to PKCS #11.", privateKey.getClass());
+            throw new CryptoException(errorMessage);
+        }
+
+        java.security.interfaces.RSAPrivateKey rsaPrivateKeySpec = (java.security.interfaces.RSAPrivateKey) privateKey;
+        RSAPrivateKey rsaPrivateKey = new RSAPrivateKey();
+        rsaPrivateKey.getModulus().setByteArrayValue(rsaPrivateKeySpec.getModulus().toByteArray());
+        rsaPrivateKey.getPrivateExponent().setByteArrayValue(rsaPrivateKeySpec.getPrivateExponent().toByteArray());
+        logDebug("Successfully mapped JCE RSA private key to PKCS #11 RSA private key.");
+        return rsaPrivateKey;
+    }
+
+    /**
+     * This static method maps PKCS 11 private key to JCE private key.
+     *
+     * @param privateKey : PKCS 11 Private key.
+     * @return JCE private key {@link java.security.PrivateKey}.
+     * @throws CryptoException
+     */
+    public static java.security.PrivateKey mapPrivateKeyPKCS11ToJCE(PrivateKey privateKey) throws CryptoException {
+
+        if (!(privateKey instanceof RSAPrivateKey)) {
+            String errorMessage = String.format("PKCS11 JCE object mapper doesn't support for conversion of %s type " +
+                    "private keys from PKCS #11 to JCE.", privateKey.getClass());
+            throw new CryptoException(errorMessage);
+        }
+
+        logDebug("Mapping PKCS #11 RSA private key to JCE RSA private key.");
+        RSAPrivateKey retrievedRSAKey = (RSAPrivateKey) privateKey;
+        BigInteger privateExponent = new BigInteger(retrievedRSAKey.
+                getPrivateExponent().getByteArrayValue());
+        BigInteger modulus = new BigInteger(retrievedRSAKey.getModulus().getByteArrayValue());
+        String keyGenerationAlgorithm = "RSA";
+        try {
+            java.security.PrivateKey generatedKey = KeyFactory.getInstance(keyGenerationAlgorithm).generatePrivate(new
+                    RSAPrivateKeySpec(modulus, privateExponent));
+            logDebug("Successfully mapped PKCS #11 RSA private key to JCE RSA private key.");
+            return generatedKey;
+        } catch (InvalidKeySpecException e) {
+            String errorMessage = String.format("Provided key specification is invalid for key alias '%s'",
+                    new String(privateKey.getLabel().getCharArrayValue()));
+            throw new CryptoException(errorMessage, e);
+        } catch (NoSuchAlgorithmException e) {
+            String errorMessage = String.format("Invalid key generation algorithm '%s'.", keyGenerationAlgorithm);
+            throw new CryptoException(errorMessage, e);
+        }
+    }
+
+    protected static RSAPublicKey mapRSAPublicKeyJCEToPKCS11(X509Certificate x509Certificate)
+            throws CryptoException {
+
+        PublicKey publicKey = x509Certificate.getPublicKey();
+        if (!(publicKey instanceof java.security.interfaces.RSAPublicKey)) {
+            String errorMessage = String.format("PKCS11 JCE object mapper doesn't support for conversion of %s type " +
+                    "public keys from JCE to PKCS #11.", publicKey.getClass());
+            throw new CryptoException(errorMessage);
+        }
+        java.security.interfaces.RSAPublicKey rsaPublicKeySpec = (java.security.interfaces.RSAPublicKey) publicKey;
+        RSAPublicKey rsaPublicKey = new RSAPublicKey();
+        rsaPublicKey.getSubject().setByteArrayValue(x509Certificate.getSubjectX500Principal().getEncoded());
+        rsaPublicKey.getModulus().setByteArrayValue(rsaPublicKeySpec.getModulus().toByteArray());
+        rsaPublicKey.getPublicExponent().setByteArrayValue(rsaPublicKeySpec.getPublicExponent().toByteArray());
+        logDebug("Successfully mapped JCE RSA public key to PKCS #11 public key.");
+        return rsaPublicKey;
+    }
+
+    protected static X509PublicKeyCertificate mapX509CertJCEToPKCS11(X509Certificate x509Certificate)
+            throws CryptoException {
+
+        X509PublicKeyCertificate cert = new X509PublicKeyCertificate();
+        cert.getSubject().setByteArrayValue(x509Certificate.getSubjectX500Principal().getEncoded());
+        cert.getIssuer().setByteArrayValue(x509Certificate.getIssuerX500Principal().getEncoded());
+        cert.getSerialNumber().setByteArrayValue(x509Certificate.getSerialNumber().toByteArray());
+        try {
+            cert.getValue().setByteArrayValue(x509Certificate.getEncoded());
+        } catch (CertificateEncodingException e) {
+            String errorMessage = "Error occurred while encoding the certificate.";
+            throw new CryptoException(errorMessage, e);
+        }
+        logDebug("Successfully mapped X509 Java certificate to PKCS #11 certificate.");
+        return cert;
+    }
+
+    protected static void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/PKCS11JCEObjectMapper.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/PKCS11JCEObjectMapper.java
@@ -64,7 +64,9 @@ public class PKCS11JCEObjectMapper {
         X509Certificate x509Certificate = (X509Certificate) certificate;
         X509PublicKeyCertificate cert = mapX509CertJCEToPKCS11(x509Certificate);
         RSAPublicKey rsaPublicKey = mapRSAPublicKeyJCEToPKCS11(x509Certificate);
-        logDebug("Successfully mapped PKCS #11 X.509 public certificate to JCE X.509 public certificate.");
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully mapped PKCS #11 X.509 public certificate to JCE X.509 public certificate.");
+        }
         return new PKCS11CertificateData(cert, rsaPublicKey);
     }
 
@@ -83,12 +85,16 @@ public class PKCS11JCEObjectMapper {
                     "%s type certificates from PKCS #11 to JCE.", certificate.getClass());
             throw new CryptoException(errorMessage);
         }
-        logDebug("Mapping JCE X.509 public certificate to PKCS #11 X.509 public certificate.");
+        if (log.isDebugEnabled()) {
+            log.debug("Mapping JCE X.509 public certificate to PKCS #11 X.509 public certificate.");
+        }
         byte[] x509Certificate = ((X509PublicKeyCertificate) certificate).getValue().getByteArrayValue();
         try {
             java.security.cert.Certificate generatedCertificate = CertificateFactory.getInstance("X.509")
                     .generateCertificate(new ByteArrayInputStream(x509Certificate));
-            logDebug("Successfully mapped JCE X.509 public certificate to PKCS #11 X.509 public certificate.");
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully mapped JCE X.509 public certificate to PKCS #11 X.509 public certificate.");
+            }
             return generatedCertificate;
         } catch (CertificateException e) {
             String errorMessage = String.format("Error occurred while generating X.509 certificate from the " +
@@ -116,7 +122,9 @@ public class PKCS11JCEObjectMapper {
         RSAPrivateKey rsaPrivateKey = new RSAPrivateKey();
         rsaPrivateKey.getModulus().setByteArrayValue(rsaPrivateKeySpec.getModulus().toByteArray());
         rsaPrivateKey.getPrivateExponent().setByteArrayValue(rsaPrivateKeySpec.getPrivateExponent().toByteArray());
-        logDebug("Successfully mapped JCE RSA private key to PKCS #11 RSA private key.");
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully mapped JCE RSA private key to PKCS #11 RSA private key.");
+        }
         return rsaPrivateKey;
     }
 
@@ -134,8 +142,9 @@ public class PKCS11JCEObjectMapper {
                     "private keys from PKCS #11 to JCE.", privateKey.getClass());
             throw new CryptoException(errorMessage);
         }
-
-        logDebug("Mapping PKCS #11 RSA private key to JCE RSA private key.");
+        if (log.isDebugEnabled()) {
+            log.debug("Mapping PKCS #11 RSA private key to JCE RSA private key.");
+        }
         RSAPrivateKey retrievedRSAKey = (RSAPrivateKey) privateKey;
         BigInteger privateExponent = new BigInteger(retrievedRSAKey.
                 getPrivateExponent().getByteArrayValue());
@@ -144,7 +153,9 @@ public class PKCS11JCEObjectMapper {
         try {
             java.security.PrivateKey generatedKey = KeyFactory.getInstance(keyGenerationAlgorithm).generatePrivate(new
                     RSAPrivateKeySpec(modulus, privateExponent));
-            logDebug("Successfully mapped PKCS #11 RSA private key to JCE RSA private key.");
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully mapped PKCS #11 RSA private key to JCE RSA private key.");
+            }
             return generatedKey;
         } catch (InvalidKeySpecException e) {
             String errorMessage = String.format("Provided key specification is invalid for key alias '%s'",
@@ -170,7 +181,9 @@ public class PKCS11JCEObjectMapper {
         rsaPublicKey.getSubject().setByteArrayValue(x509Certificate.getSubjectX500Principal().getEncoded());
         rsaPublicKey.getModulus().setByteArrayValue(rsaPublicKeySpec.getModulus().toByteArray());
         rsaPublicKey.getPublicExponent().setByteArrayValue(rsaPublicKeySpec.getPublicExponent().toByteArray());
-        logDebug("Successfully mapped JCE RSA public key to PKCS #11 public key.");
+        if (log.isDebugEnabled()) {
+            log.debug("Successfully mapped JCE RSA public key to PKCS #11 public key.");
+        }
         return rsaPublicKey;
     }
 
@@ -187,14 +200,9 @@ public class PKCS11JCEObjectMapper {
             String errorMessage = "Error occurred while encoding the certificate.";
             throw new CryptoException(errorMessage, e);
         }
-        logDebug("Successfully mapped X509 Java certificate to PKCS #11 certificate.");
-        return cert;
-    }
-
-    protected static void logDebug(String message) {
-
         if (log.isDebugEnabled()) {
-            log.debug(message);
+            log.debug("Successfully mapped X509 Java certificate to PKCS #11 certificate.");
         }
+        return cert;
     }
 }

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/SlotInfo.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/SlotInfo.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+/**
+ * An instance of this class holds slot ID and User PIN of HSM device's slot.
+ */
+public class SlotInfo {
+
+    private int slotID;
+    private String pin;
+
+    /**
+     * Constructor of {@link SlotInfo}.
+     *
+     * @param slotID : ID of a given slot.
+     * @param pin    : User PIN of the slot related to above slot ID.
+     */
+    public SlotInfo(int slotID, String pin) {
+
+        this.slotID = slotID;
+        this.pin = pin;
+    }
+
+    public int getSlotID() {
+
+        return slotID;
+    }
+
+    public String getPin() {
+
+        return pin;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/SlotResolver.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/SlotResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.wso2.carbon.crypto.api.CryptoContext;
+
+/**
+ * The service contract for slot resolvers.
+ * Implementations of this interface resolves slots related to a given context information.
+ */
+public interface SlotResolver {
+
+    /**
+     * Resolves the slot information related to given {@link CryptoContext}.
+     *
+     * @param cryptoContext : Context information related to the given cryptographic operation.
+     * @return {@link SlotInfo}
+     */
+    SlotInfo resolveSlot(CryptoContext cryptoContext);
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/exception/HSMCryptoException.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/exception/HSMCryptoException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception;
+
+import iaik.pkcs.pkcs11.TokenException;
+import org.wso2.carbon.crypto.api.CryptoException;
+
+/**
+ * Extension of {@link CryptoException}
+ * This exception will be thrown if something unexpected happened during a HSM based crypto operation.
+ */
+public class HSMCryptoException extends CryptoException {
+
+    private String errorCode;
+
+    /**
+     * Default constructor of an exception.
+     */
+    public HSMCryptoException() {
+
+        super();
+    }
+
+    /**
+     * Constructor of {@link HSMCryptoException}.
+     *
+     * @param message : Error message.
+     * @param e       : Exception thrown.
+     */
+    public HSMCryptoException(String message, Throwable e) {
+
+        super(message, e);
+        if (e instanceof TokenException) {
+            this.errorCode = e.getMessage();
+        }
+    }
+
+    public String getErrorCode() {
+
+        return this.errorCode;
+    }
+
+    protected void setErrorCode(String errorCode) {
+
+        this.errorCode = errorCode;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/CertificateHandler.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/CertificateHandler.java
@@ -55,6 +55,7 @@ public class CertificateHandler {
 
         try {
             session.findObjectsInit(certificateTemplate);
+            // Retrieves certificate object matching to given template.
             Object[] certificateArray = session.findObjects(1);
             if (certificateArray.length > 0) {
                 if (log.isDebugEnabled()) {
@@ -82,8 +83,10 @@ public class CertificateHandler {
      */
     public void storeCertificate(Certificate certificate) throws HSMCryptoException {
 
+        // Make the certificate a token object.
         certificate.getToken().setBooleanValue(true);
         try {
+            // Store the certificate in the slot related to session.
             session.createObject(certificate);
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Certificate with alias %s, stored successfully in HSM device.",

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/CertificateHandler.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/CertificateHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers;
+
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.TokenException;
+import iaik.pkcs.pkcs11.objects.Certificate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+
+/**
+ * This class is responsible to handle certificate related operations with HSM.
+ */
+public class CertificateHandler {
+
+    private static Log log = LogFactory.getLog(CertificateHandler.class);
+
+    private final Session session;
+
+    /**
+     * Constructor of CertificateHandler instance.
+     *
+     * @param session : Session associated to handle the certificate related operation.
+     */
+    public CertificateHandler(Session session) {
+
+        this.session = session;
+    }
+
+    /**
+     * Method to retrieve a given certificate from the HSM.
+     *
+     * @param certificateTemplate : Template of the certificate to be retrieved
+     * @return retrievedCertificate
+     */
+    public Certificate getCertificate(Certificate certificateTemplate) throws CryptoException {
+
+        try {
+            session.findObjectsInit(certificateTemplate);
+            Object[] certificateArray = session.findObjects(1);
+            if (certificateArray.length > 0) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("Certificate with alias %s, retrieved successfully from HSM device.",
+                            new String(certificateTemplate.getLabel().getCharArrayValue())));
+                }
+                return (Certificate) certificateArray[0];
+            } else {
+                String errorMessage = String.format("Requested certificate '%s' can't be found inside the HSM.",
+                        String.valueOf(certificateTemplate.getLabel().getCharArrayValue()));
+                throw new CryptoException(errorMessage);
+            }
+        } catch (TokenException e) {
+            String errorMessage = String.format("Error occurred during retrieving certificate with alias '%s'.",
+                    String.valueOf(certificateTemplate.getLabel().getCharArrayValue()));
+            throw new HSMCryptoException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Store a PKCS #11 certificate in the HSM device.
+     *
+     * @param certificate : Certificate that needs to be stored.
+     * @throws HSMCryptoException
+     */
+    public void storeCertificate(Certificate certificate) throws HSMCryptoException {
+
+        certificate.getToken().setBooleanValue(true);
+        try {
+            session.createObject(certificate);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Certificate with alias %s, stored successfully in HSM device.",
+                        new String(certificate.getLabel().getCharArrayValue())));
+            }
+        } catch (TokenException e) {
+            String errorMessage = String.format("Error occurred while storing %s certificate in HSM device.",
+                    new String(certificate.getLabel().getCharArrayValue()));
+            throw new HSMCryptoException(errorMessage, e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/KeyHandler.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/KeyHandler.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.TokenException;
+import iaik.pkcs.pkcs11.objects.Key;
+import iaik.pkcs.pkcs11.objects.SecretKey;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+
+/**
+ * This class is responsible to handle key related operations with HSM.
+ */
+public class KeyHandler {
+
+    private static Log log = LogFactory.getLog(KeyHandler.class);
+
+    private final Session session;
+
+    /**
+     * Constructor of key handler instance.
+     *
+     * @param session : Session associated to handle the key related operation.
+     */
+    public KeyHandler(Session session) {
+
+        this.session = session;
+    }
+
+    /**
+     * Method to retrieve key when template of the key is given.
+     *
+     * @param keyTemplate : Template of the key to be retrieved.
+     * @return retrieved key
+     * @throws CryptoException
+     */
+    public Key retrieveKey(Key keyTemplate) throws CryptoException {
+
+        try {
+            session.findObjectsInit(keyTemplate);
+            Object[] keyArray = session.findObjects(1);
+            if (keyArray.length > 0) {
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("A key with alias %s was retrieved from HSM device.",
+                            new String(keyTemplate.getLabel().getCharArrayValue())));
+                }
+                return (Key) keyArray[0];
+            } else {
+                String errorMessage = String.format("Requested key with key alias %s can't be found inside the HSM.",
+                        String.valueOf(keyTemplate.getLabel().getCharArrayValue()));
+                throw new CryptoException(errorMessage);
+            }
+        } catch (TokenException e) {
+            String errorMessage = String.format("Error occurred while retrieving key for key alias '%s'.",
+                    new String(keyTemplate.getLabel().getCharArrayValue()));
+            throw new HSMCryptoException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Generates symmetric keys conforming to given secret key template.
+     *
+     * @param secretKeyTemplate : Template of the key that needs to be generated.
+     * @param mechanism         : Key generation mechanism.
+     * @return : Generated Key {@link SecretKey}
+     * @throws HSMCryptoException
+     */
+    public SecretKey generateSecretKey(SecretKey secretKeyTemplate, Mechanism mechanism) throws HSMCryptoException {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Generating a session secret key with %s mechanism using HSM device.",
+                    mechanism.getName()));
+        }
+        try {
+            return (SecretKey) session.generateKey(mechanism, secretKeyTemplate);
+        } catch (TokenException e) {
+            String errorMessage = String.format("Error occurred while generating a %s secret key as a session object.",
+                    mechanism.getName());
+            throw new HSMCryptoException(errorMessage, e);
+        }
+    }
+
+    /**
+     * When an external key is used for a cryptographic operation,
+     * it is necessary get a object handle from HSM for the key.
+     * This creates handle for the given {@link Key} inside the HSM.
+     *
+     * @param key : The key which requires a handle.
+     * @return : {@link Key} with object handle. This is a session object.
+     * @throws HSMCryptoException
+     */
+    public Key getKeyHandle(Key key) throws HSMCryptoException {
+
+        try {
+            return (Key) session.createObject(key);
+        } catch (TokenException e) {
+            String errorMessage = String.format("Error occurred while generating an object handle for given %s key.",
+                    String.valueOf(key.getLabel().getCharArrayValue()));
+            throw new HSMCryptoException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Store a given key in the HSM device.
+     *
+     * @param key : PKCS #11 key that needs to be stored in the HSM.
+     * @throws HSMCryptoException
+     */
+    public void storeKey(Key key) throws HSMCryptoException {
+
+        key.getToken().setBooleanValue(true);
+        try {
+            session.createObject(key);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("A key with alias %s stored in HSM device.",
+                        new String(key.getLabel().getCharArrayValue())));
+            }
+        } catch (TokenException e) {
+            String errorMessage = String.format("Error occurred while storing %s key in HSM device.",
+                    new String(key.getLabel().getCharArrayValue()));
+            throw new HSMCryptoException(errorMessage, e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/Cipher.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/Cipher.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.TokenException;
+import iaik.pkcs.pkcs11.objects.Key;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+
+/**
+ * This class is responsible for carrying out encrypt/decrypt operations.
+ */
+public class Cipher {
+
+    private static Log log = LogFactory.getLog(Cipher.class);
+
+    private final Session session;
+
+    /**
+     * Constructor of a Cipher instance.
+     *
+     * @param session : Session used for the encryption/decryption operation.
+     */
+    public Cipher(Session session) {
+
+        this.session = session;
+    }
+
+    /**
+     * Method to encrypt a given set of data using a given key.
+     * Encryption is handled by the underlying HSM device.
+     *
+     * @param dataToBeEncrypted   : Byte array of data to be encrypted.
+     * @param encryptionKey       : Key used for encryption.
+     * @param encryptionMechanism : Encrypting mechanism.
+     * @return : Byte array of encrypted data.
+     * @throws CryptoException
+     */
+    public byte[] encrypt(byte[] dataToBeEncrypted,
+                          Key encryptionKey, Mechanism encryptionMechanism) throws CryptoException {
+
+        if (isEncryptDecryptMechanism(encryptionMechanism)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Encrypting data using the HSM device with %s mechanism.",
+                        encryptionMechanism.getName()));
+            }
+            try {
+                session.encryptInit(encryptionMechanism, encryptionKey);
+                return session.encrypt(dataToBeEncrypted);
+            } catch (TokenException e) {
+                String errorMessage = String.format("Error occurred while encrypting data using algorithm '%s'.",
+                        encryptionMechanism.getName());
+                throw new HSMCryptoException(errorMessage, e);
+            }
+        } else {
+            String errorMessage = String.format("Requested '%s' algorithm for data encryption is not a valid data " +
+                    "encryption mechanism.", encryptionMechanism.getName());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    /**
+     * Method to decrypt a given set of data using a given key.
+     * Decryption is handled by the underlying HSM device.
+     *
+     * @param dataToBeDecrypted   : Byte array of data to be decrypted.
+     * @param decryptionKey       : Key used for decryption.
+     * @param decryptionMechanism : Decrypting mechanism.
+     * @return : Byte array of decrypted data
+     * @throws CryptoException
+     */
+    public byte[] decrypt(byte[] dataToBeDecrypted,
+                          Key decryptionKey, Mechanism decryptionMechanism) throws CryptoException {
+
+        if (isEncryptDecryptMechanism(decryptionMechanism)) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Decrypting data using the HSM device with %s mechanism.",
+                        decryptionMechanism.getName()));
+            }
+            try {
+                session.decryptInit(decryptionMechanism, decryptionKey);
+                return session.decrypt(dataToBeDecrypted);
+            } catch (TokenException e) {
+                String errorMessage = String.format("Error occurred while decrypting data using algorithm '%s'.",
+                        decryptionMechanism.getName());
+                throw new HSMCryptoException(errorMessage, e);
+            }
+        } else {
+            String errorMessage = String.format("Requested '%s' algorithm for data decryption is not a valid data " +
+                    "decryption mechanism.", decryptionMechanism.getName());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected boolean isEncryptDecryptMechanism(Mechanism mechanism) {
+
+        if (mechanism.isSingleOperationEncryptDecryptMechanism()
+                || mechanism.isFullEncryptDecryptMechanism()) {
+            return true;
+        }
+        if (mechanism.getMechanismCode() == PKCS11Constants.CKM_AES_GCM) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/SignatureHandler.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/SignatureHandler.java
@@ -103,7 +103,7 @@ public class SignatureHandler {
                 session.verify(dataToVerify, signature);
                 verified = true;
             } catch (TokenException e) {
-                //PKCS #11 standard error code for signature verification failure.
+                // Check if the PKCS #11 standard error code for signature verification failure is thrown.
                 if (!e.getMessage().equals("CKR_SIGNATURE_INVALID")) {
                     String errorMessage = String.format("Error occurred during verifying the signature using " +
                             "algorithm '%s'.", verifyMechanism.getName());

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/SignatureHandler.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/SignatureHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.TokenException;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+
+/**
+ * This class is responsible for handling sign/verify operations.
+ */
+public class SignatureHandler {
+
+    private static Log log = LogFactory.getLog(SignatureHandler.class);
+
+    private final Session session;
+
+    /**
+     * Constructor for signature handler.
+     *
+     * @param session : Session used to perform sign/verify operation.
+     */
+    public SignatureHandler(Session session) {
+
+        this.session = session;
+    }
+
+    /**
+     * Method to digitally sign a given data with the given mechanism.
+     *
+     * @param dataToSign    : Data to be signed.
+     * @param signMechanism : Signing mechanism
+     * @param signKey       : Key used for signing.
+     * @return signature as a byte array.
+     * @throws CryptoException
+     */
+    public byte[] sign(byte[] dataToSign,
+                       PrivateKey signKey, Mechanism signMechanism) throws CryptoException {
+
+        if (signMechanism.isFullSignVerifyMechanism() ||
+                signMechanism.isSingleOperationSignVerifyMechanism()) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Signing data using the HSM device with %s mechanism.",
+                        signMechanism.getName()));
+            }
+            try {
+                session.signInit(signMechanism, signKey);
+                return session.sign(dataToSign);
+            } catch (TokenException e) {
+                String errorMessage = String.format("Error occurred during signature generation using algorithm '%s'.",
+                        signMechanism.getName());
+                throw new HSMCryptoException(errorMessage, e);
+            }
+        } else {
+            String errorMessage = String.format("Requested '%s' algorithm for data signing is not a valid " +
+                    "signing mechanism.", signMechanism.getName());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    /**
+     * Method to verify a given data with given mechanism.
+     *
+     * @param dataToVerify    : Data to be verified.
+     * @param signature       : Signature of the data.
+     * @param verifyMechanism : verifying mechanism.
+     * @param verificationKey : Key used for verification.
+     * @return True if verified.
+     */
+    public boolean verify(byte[] dataToVerify, byte[] signature,
+                          PublicKey verificationKey, Mechanism verifyMechanism) throws CryptoException {
+
+        boolean verified = false;
+        if (verifyMechanism.isFullSignVerifyMechanism()) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Verifying signature using the HSM device with %s mechanism.",
+                        verifyMechanism.getName()));
+            }
+            try {
+                session.verifyInit(verifyMechanism, verificationKey);
+                session.verify(dataToVerify, signature);
+                verified = true;
+            } catch (TokenException e) {
+                //PKCS #11 standard error code for signature verification failure.
+                if (!e.getMessage().equals("CKR_SIGNATURE_INVALID")) {
+                    String errorMessage = String.format("Error occurred during verifying the signature using " +
+                            "algorithm '%s'.", verifyMechanism.getName());
+                    throw new HSMCryptoException(errorMessage, e);
+                }
+            }
+        } else {
+            String errorMessage = String.format("Requested '%s' algorithm for signature verification is not a " +
+                    "valid sign verification mechanism.", verifyMechanism.getName());
+            throw new CryptoException(errorMessage);
+        }
+        return verified;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/CryptoConstants.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/CryptoConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+/**
+ * This class keeps required constants for Crypto Handler operations.
+ */
+public class CryptoConstants {
+
+    public static final int ENCRYPT_MODE = 1;
+    public static final int DECRYPT_MODE = 2;
+    public static final int SIGN_MODE = 3;
+    public static final int VERIFY_MODE = 4;
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/CryptoConstants.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/CryptoConstants.java
@@ -27,4 +27,13 @@ public class CryptoConstants {
     public static final int DECRYPT_MODE = 2;
     public static final int SIGN_MODE = 3;
     public static final int VERIFY_MODE = 4;
+
+    public static class KeyType {
+
+        public static final String AES = "AES";
+        public static final String DES = "DES";
+        public static final String DES2 = "DES2";
+        public static final String DESede = "DESede";
+        public static final String DES3 = "3DES";
+    }
 }

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/KeyTemplateGenerator.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/KeyTemplateGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import iaik.pkcs.pkcs11.objects.AESSecretKey;
+import iaik.pkcs.pkcs11.objects.DES2SecretKey;
+import iaik.pkcs.pkcs11.objects.DES3SecretKey;
+import iaik.pkcs.pkcs11.objects.DESSecretKey;
+import iaik.pkcs.pkcs11.objects.SecretKey;
+
+/**
+ * This class generates symmetric key templates required for symmetric key generation.
+ */
+public class KeyTemplateGenerator {
+
+    /**
+     * Generates a {@link AESSecretKey} template with required attributes.
+     *
+     * @return {@link AESSecretKey} template.
+     */
+    public static AESSecretKey generateAESKeyTemplate() {
+
+        AESSecretKey aesSecretKeyTemplate = new AESSecretKey();
+        aesSecretKeyTemplate.getLabel().setCharArrayValue("AES".toCharArray());
+        updateCommonAttributes(aesSecretKeyTemplate);
+        return aesSecretKeyTemplate;
+    }
+
+    /**
+     * Generates a {@link DESSecretKey} template with required attributes.
+     *
+     * @return {@link DESSecretKey} template.
+     */
+    public static DESSecretKey generateDESKeyTemplate() {
+
+        DESSecretKey desSecretKeyTemplate = new DESSecretKey();
+        desSecretKeyTemplate.getLabel().setCharArrayValue("DES".toCharArray());
+        updateCommonAttributes(desSecretKeyTemplate);
+        return desSecretKeyTemplate;
+    }
+
+    /**
+     * Generates a {@link DES3SecretKey} template with required attributes.
+     *
+     * @return {@link DES3SecretKey} template.
+     */
+    public static DES3SecretKey generateDES3KeyTemplate() {
+
+        DES3SecretKey des3SecretKeyTemplate = new DES3SecretKey();
+        des3SecretKeyTemplate.getLabel().setCharArrayValue("DES3".toCharArray());
+        updateCommonAttributes(des3SecretKeyTemplate);
+        return des3SecretKeyTemplate;
+    }
+
+    /**
+     * Generates a {@link DES2SecretKey} template with required attributes.
+     *
+     * @return {@link DES2SecretKey} template.
+     */
+    public static DES2SecretKey generateDES2KeyTemplate() {
+
+        DES2SecretKey des2SecretKeyTemplate = new DES2SecretKey();
+        des2SecretKeyTemplate.getLabel().setCharArrayValue("DES2".toCharArray());
+        updateCommonAttributes(des2SecretKeyTemplate);
+        return des2SecretKeyTemplate;
+    }
+
+    protected static void updateCommonAttributes(SecretKey keyTemplate) {
+
+        keyTemplate.getExtractable().setBooleanValue(true);
+        keyTemplate.getSensitive().setBooleanValue(false);
+        keyTemplate.getToken().setBooleanValue(false);
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismDataHolder.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismDataHolder.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import java.security.spec.AlgorithmParameterSpec;
+
+/**
+ * A given instance holds required data to resolve a mechanism with parameters.
+ */
+public class MechanismDataHolder {
+
+    private int operatingMode;
+    private String jceMechanismSpecification;
+    private AlgorithmParameterSpec algorithmParameterSpec;
+    private byte[] authData;
+
+    /**
+     * Constructor of a {@link MechanismDataHolder} instance with only operating mode and algorithm specification.
+     *
+     * @param operatingMode             : Mode of cryptographic operation
+     * @param jceMechanismSpecification : Standard JCE name of the mechanism.
+     */
+    public MechanismDataHolder(int operatingMode, String jceMechanismSpecification) {
+
+        this.operatingMode = operatingMode;
+        this.jceMechanismSpecification = jceMechanismSpecification;
+        this.algorithmParameterSpec = null;
+        this.authData = null;
+    }
+
+    /**
+     * Constructor of a {@link MechanismDataHolder} instance with only operating mode, algorithm specification
+     * and algorithm parameters.
+     *
+     * @param operatingMode             : Mode of cryptographic operation
+     * @param jceMechanismSpecification : Standard JCE name of the mechanism.
+     * @param algorithmParameterSpec    : Algorithm parameter specification.
+     */
+    public MechanismDataHolder(int operatingMode, String jceMechanismSpecification, AlgorithmParameterSpec algorithmParameterSpec) {
+
+        this.operatingMode = operatingMode;
+        this.jceMechanismSpecification = jceMechanismSpecification;
+        this.algorithmParameterSpec = algorithmParameterSpec;
+        this.authData = null;
+    }
+
+    /**
+     * Constructor of a {@link MechanismDataHolder} instance with only operating mode, algorithm specification,
+     * algorithm parameters and authentication data.
+     *
+     * @param operatingMode             : Mode of cryptographic operation
+     * @param jceMechanismSpecification : Standard JCE name of the mechanism.
+     * @param algorithmParameterSpec    : Algorithm parameter specification.
+     * @param authData                  : Authentication data.
+     */
+    public MechanismDataHolder(int operatingMode, String jceMechanismSpecification, AlgorithmParameterSpec algorithmParameterSpec,
+                               byte[] authData) {
+
+        this.operatingMode = operatingMode;
+        this.jceMechanismSpecification = jceMechanismSpecification;
+        this.algorithmParameterSpec = algorithmParameterSpec;
+        this.authData = authData;
+    }
+
+    /**
+     * Constructor of a {@link MechanismDataHolder} instance with only operating mode, algorithm specification,
+     * and authentication data.
+     *
+     * @param operatingMode             : Mode of cryptographic operation
+     * @param jceMechanismSpecification : Standard JCE name of the mechanism.
+     * @param authData                  : Authentication data.
+     */
+    public MechanismDataHolder(int operatingMode, String jceMechanismSpecification, byte[] authData) {
+
+        this.operatingMode = operatingMode;
+        this.jceMechanismSpecification = jceMechanismSpecification;
+        this.authData = authData;
+        this.algorithmParameterSpec = null;
+    }
+
+    public String getJceMechanismSpecification() {
+
+        return jceMechanismSpecification;
+    }
+
+    public AlgorithmParameterSpec getAlgorithmParameterSpec() {
+
+        return algorithmParameterSpec;
+    }
+
+    public byte[] getAuthData() {
+
+        return authData;
+    }
+
+    public int getOperatingMode() {
+
+        return operatingMode;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismResolver.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismResolver.java
@@ -58,12 +58,12 @@ public class MechanismResolver {
         /*
          * Encrypt/Decrypt mechanisms
          */
-        //DES mechanisms
+        // DES mechanisms
         put("DES/CBC/NoPadding", PKCS11Constants.CKM_DES_CBC);
         put("DES/CBC/PKCS5Padding", PKCS11Constants.CKM_DES_CBC_PAD);
         put("DES/ECB/NoPadding", PKCS11Constants.CKM_DES_ECB);
 
-        //DES3 mechanisms
+        // DES3 mechanisms
         put("DESede/CBC/NoPadding", PKCS11Constants.CKM_DES3_CBC);
         put("3DES/CBC/NoPadding", PKCS11Constants.CKM_DES3_CBC);
         put("DESede/CBC/PKCS5Padding", PKCS11Constants.CKM_DES3_CBC_PAD);
@@ -71,7 +71,7 @@ public class MechanismResolver {
         put("DESede/ECB/NoPadding", PKCS11Constants.CKM_DES3_ECB);
         put("3DES/ECB/NoPadding", PKCS11Constants.CKM_DES3_ECB);
 
-        //AES mechanisms
+        // AES mechanisms
         put("AES/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
         put("AES_128/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
         put("AES_192/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
@@ -89,7 +89,7 @@ public class MechanismResolver {
         put("AES_192/GCM/NoPadding", PKCS11Constants.CKM_AES_GCM);
         put("AES_256/GCM/NoPadding", PKCS11Constants.CKM_AES_GCM);
 
-        //RSA mechanisms
+        // RSA mechanisms
         put("RSA/ECB/OAEPwithMD5andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
         put("RSA/ECB/OAEPwithSHA1andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
         put("RSA/ECB/OAEPwithSHA256andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
@@ -99,18 +99,18 @@ public class MechanismResolver {
         put("RSA/ECB/NoPadding", PKCS11Constants.CKM_RSA_X_509);
         put("RSA/ECB/ISO9796Padding", PKCS11Constants.CKM_RSA_9796);
 
-        //Blowfish mechanisms
+        // Blowfish mechanisms
         put("Blowfish/CBC/NoPadding", PKCS11Constants.CKM_BLOWFISH_CBC);
         put("Blowfish/CBC/PKCS5Padding", PKCS11Constants.CKM_BLOWFISH_CBC);
 
         /*
          * Sign/Verify mechanisms
          */
-        //ECDSA sign/verify mechanisms
+        // ECDSA sign/verify mechanisms
         put("NONEwithECDSA", PKCS11Constants.CKM_ECDSA);
         put("SHA1withECDSA", PKCS11Constants.CKM_ECDSA_SHA1);
 
-        //RSA sign/verify mechanisms
+        // RSA sign/verify mechanisms
         put("MD2withRSA", PKCS11Constants.CKM_MD2_RSA_PKCS);
         put("MD5withRSA", PKCS11Constants.CKM_MD5_RSA_PKCS);
         put("SHA1withRSA", PKCS11Constants.CKM_SHA1_RSA_PKCS);
@@ -125,7 +125,7 @@ public class MechanismResolver {
         put("SHA384withRSAandMGF1", PKCS11Constants.CKM_SHA384_RSA_PKCS_PSS);
         put("SHA512withRSAandMGF1", PKCS11Constants.CKM_SHA512_RSA_PKCS_PSS);
 
-        //DSA sign/verify mechanisms
+        // DSA sign/verify mechanisms
         put("RawDSA", PKCS11Constants.CKM_DSA);
         put("SHA1withDSA", PKCS11Constants.CKM_DSA_SHA1);
 
@@ -196,14 +196,18 @@ public class MechanismResolver {
     public Mechanism resolveMechanism(MechanismDataHolder mechanismDataHolder) throws CryptoException {
 
         if (mechanisms.containsKey(mechanismDataHolder.getJceMechanismSpecification())) {
-            logDebug(String.format("Resolving PKCS #11 mechanism for '%s' JCE standard algorithm.",
-                    mechanismDataHolder.getJceMechanismSpecification()));
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Resolving PKCS #11 mechanism for '%s' JCE standard algorithm.",
+                        mechanismDataHolder.getJceMechanismSpecification()));
+            }
             Mechanism mechanism = Mechanism.get(mechanisms.get(mechanismDataHolder.getJceMechanismSpecification()));
             if (parameterRequiredMechanisms.containsKey(mechanism.getMechanismCode())) {
                 resolveParameters(mechanism, mechanismDataHolder);
             }
-            logDebug(String.format("Successfully resolved PKCS #11 mechanism for '%s' JCE standard algorithm.",
-                    mechanismDataHolder.getJceMechanismSpecification()));
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Successfully resolved PKCS #11 mechanism for '%s' JCE standard algorithm.",
+                        mechanismDataHolder.getJceMechanismSpecification()));
+            }
             return mechanism;
         } else {
             String errorMessage = String.format("Requested %s algorithm is not supported by HSM based crypto provider.",
@@ -229,12 +233,17 @@ public class MechanismResolver {
             mechanism.setParameters(getGCMParameters((GCMParameterSpec) mechanismDataHolder.getAlgorithmParameterSpec(),
                     mechanismDataHolder.getOperatingMode(), 12, mechanismDataHolder.getAuthData()));
         }
-        logDebug(String.format("Successfully resolved parameters for '%s' PKCS #11 mechanism.", mechanism.getName()));
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Successfully resolved parameters for '%s' PKCS #11 mechanism.",
+                    mechanism.getName()));
+        }
     }
 
     protected RSAPkcsOaepParameters getOAEPParameters(String parameter) throws CryptoException {
 
-        logDebug(String.format("Resolving RSA OAEP algorithm parameters."));
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Resolving RSA OAEP algorithm parameters."));
+        }
         String[] specParams = parameter.split("with");
         String[] oaepParams = specParams[1].split("and");
         if (mechanisms.containsKey(oaepParams[0])) {
@@ -248,8 +257,10 @@ public class MechanismResolver {
 
     protected RSAPkcsPssParameters getRSAPSSParameters(String algorithmSpecification) throws CryptoException {
 
-        logDebug(String.format("Resolving RSA PSS algorithm parameters for %s algorithm.",
-                algorithmSpecification));
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Resolving RSA PSS algorithm parameters for %s algorithm.",
+                    algorithmSpecification));
+        }
         if (algorithmSpecification.contains("SHA1")) {
             return new RSAPkcsPssParameters(Mechanism.get(mechanisms.get("SHA1")), 1L,
                     20L);
@@ -272,7 +283,9 @@ public class MechanismResolver {
                                                                                int operatingMode, int ivSize)
             throws CryptoException {
 
-        logDebug("Resolving initialization vector parameters.");
+        if (log.isDebugEnabled()) {
+            log.debug("Resolving initialization vector parameters.");
+        }
         if (operatingMode == ENCRYPT_MODE) {
             return new InitializationVectorParameters(generateIV(ivSize));
         } else if (operatingMode == DECRYPT_MODE) {
@@ -291,7 +304,9 @@ public class MechanismResolver {
     protected GcmParameters getGCMParameters(GCMParameterSpec gcmParameterSpec, int operatingMode, int ivSize,
                                              byte[] authData) throws CryptoException {
 
-        logDebug("Resolving GCM parameters.");
+        if (log.isDebugEnabled()) {
+            log.debug("Resolving GCM parameters.");
+        }
         if (operatingMode == ENCRYPT_MODE) {
             return new GcmParameters(generateIV(ivSize), authData, 128);
         } else if (operatingMode == DECRYPT_MODE) {
@@ -312,12 +327,5 @@ public class MechanismResolver {
         byte[] iv = new byte[size];
         random.nextBytes(iv);
         return iv;
-    }
-
-    protected void logDebug(String message) {
-
-        if (log.isDebugEnabled()) {
-            log.debug(message);
-        }
     }
 }

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismResolver.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismResolver.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.parameters.GcmParameters;
+import iaik.pkcs.pkcs11.parameters.InitializationVectorParameters;
+import iaik.pkcs.pkcs11.parameters.RSAPkcsOaepParameters;
+import iaik.pkcs.pkcs11.parameters.RSAPkcsPssParameters;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.crypto.api.CryptoException;
+
+import java.security.SecureRandom;
+import java.util.HashMap;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.DECRYPT_MODE;
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.ENCRYPT_MODE;
+
+/**
+ * This class is used to resolve JCE standard mechanism names to PKCS #11 mechanisms.
+ */
+public class MechanismResolver {
+
+    private static MechanismResolver defaultMechanismResolver = new MechanismResolver();
+    private static Log log = LogFactory.getLog(MechanismResolver.class);
+    private static SecureRandom random = new SecureRandom();
+    private static HashMap<String, Long> mechanisms = new HashMap<String, Long>() {{
+
+        /*
+         * Key generation mechanisms
+         */
+        put("AES", PKCS11Constants.CKM_AES_KEY_GEN);
+        put("DES", PKCS11Constants.CKM_DES_KEY_GEN);
+        put("DES2", PKCS11Constants.CKM_DES2_KEY_GEN);
+        put("3DES", PKCS11Constants.CKM_DES3_KEY_GEN);
+        put("DESede", PKCS11Constants.CKM_DES3_KEY_GEN);
+
+        /*
+         * Encrypt/Decrypt mechanisms
+         */
+        //DES mechanisms
+        put("DES/CBC/NoPadding", PKCS11Constants.CKM_DES_CBC);
+        put("DES/CBC/PKCS5Padding", PKCS11Constants.CKM_DES_CBC_PAD);
+        put("DES/ECB/NoPadding", PKCS11Constants.CKM_DES_ECB);
+
+        //DES3 mechanisms
+        put("DESede/CBC/NoPadding", PKCS11Constants.CKM_DES3_CBC);
+        put("3DES/CBC/NoPadding", PKCS11Constants.CKM_DES3_CBC);
+        put("DESede/CBC/PKCS5Padding", PKCS11Constants.CKM_DES3_CBC_PAD);
+        put("3DES/CBC/PKCS5Padding", PKCS11Constants.CKM_DES3_CBC_PAD);
+        put("DESede/ECB/NoPadding", PKCS11Constants.CKM_DES3_ECB);
+        put("3DES/ECB/NoPadding", PKCS11Constants.CKM_DES3_ECB);
+
+        //AES mechanisms
+        put("AES/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
+        put("AES_128/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
+        put("AES_192/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
+        put("AES_256/CBC/NoPadding", PKCS11Constants.CKM_AES_CBC);
+        put("AES/CBC/PKCS5Padding", PKCS11Constants.CKM_AES_CBC_PAD);
+        put("AES_128/CBC/PKCS5Padding", PKCS11Constants.CKM_AES_CBC_PAD);
+        put("AES_192/CBC/PKCS5Padding", PKCS11Constants.CKM_AES_CBC_PAD);
+        put("AES_256/CBC/PKCS5Padding", PKCS11Constants.CKM_AES_CBC_PAD);
+        put("AES/ECB/NoPadding", PKCS11Constants.CKM_AES_ECB);
+        put("AES_128/ECB/NoPadding", PKCS11Constants.CKM_AES_ECB);
+        put("AES_192/ECB/NoPadding", PKCS11Constants.CKM_AES_ECB);
+        put("AES_256/ECB/NoPadding", PKCS11Constants.CKM_AES_ECB);
+        put("AES/GCM/NoPadding", PKCS11Constants.CKM_AES_GCM);
+        put("AES_128/GCM/NoPadding", PKCS11Constants.CKM_AES_GCM);
+        put("AES_192/GCM/NoPadding", PKCS11Constants.CKM_AES_GCM);
+        put("AES_256/GCM/NoPadding", PKCS11Constants.CKM_AES_GCM);
+
+        //RSA mechanisms
+        put("RSA/ECB/OAEPwithMD5andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
+        put("RSA/ECB/OAEPwithSHA1andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
+        put("RSA/ECB/OAEPwithSHA256andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
+        put("RSA/ECB/OAEPwithSHA384andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
+        put("RSA/ECB/OAEPwithSHA512andMGF1Padding", PKCS11Constants.CKM_RSA_PKCS_OAEP);
+        put("RSA/ECB/PKCS1Padding", PKCS11Constants.CKM_RSA_PKCS);
+        put("RSA/ECB/NoPadding", PKCS11Constants.CKM_RSA_X_509);
+        put("RSA/ECB/ISO9796Padding", PKCS11Constants.CKM_RSA_9796);
+
+        //Blowfish mechanisms
+        put("Blowfish/CBC/NoPadding", PKCS11Constants.CKM_BLOWFISH_CBC);
+        put("Blowfish/CBC/PKCS5Padding", PKCS11Constants.CKM_BLOWFISH_CBC);
+
+        /*
+         * Sign/Verify mechanisms
+         */
+        //ECDSA sign/verify mechanisms
+        put("NONEwithECDSA", PKCS11Constants.CKM_ECDSA);
+        put("SHA1withECDSA", PKCS11Constants.CKM_ECDSA_SHA1);
+
+        //RSA sign/verify mechanisms
+        put("MD2withRSA", PKCS11Constants.CKM_MD2_RSA_PKCS);
+        put("MD5withRSA", PKCS11Constants.CKM_MD5_RSA_PKCS);
+        put("SHA1withRSA", PKCS11Constants.CKM_SHA1_RSA_PKCS);
+        put("SHA256withRSA", PKCS11Constants.CKM_SHA256_RSA_PKCS);
+        put("SHA384withRSA", PKCS11Constants.CKM_SHA384_RSA_PKCS);
+        put("SHA512withRSA", PKCS11Constants.CKM_SHA512_RSA_PKCS);
+        put("RipeMd128withRSA", PKCS11Constants.CKM_RIPEMD128_RSA_PKCS);
+        put("RipeMd160withRSA", PKCS11Constants.CKM_RIPEMD160_RSA_PKCS);
+
+        put("SHA1withRSAandMGF1", PKCS11Constants.CKM_SHA1_RSA_PKCS_PSS);
+        put("SHA256withRSAandMGF1", PKCS11Constants.CKM_SHA256_RSA_PKCS_PSS);
+        put("SHA384withRSAandMGF1", PKCS11Constants.CKM_SHA384_RSA_PKCS_PSS);
+        put("SHA512withRSAandMGF1", PKCS11Constants.CKM_SHA512_RSA_PKCS_PSS);
+
+        //DSA sign/verify mechanisms
+        put("RawDSA", PKCS11Constants.CKM_DSA);
+        put("SHA1withDSA", PKCS11Constants.CKM_DSA_SHA1);
+
+        /*
+         * Digest mechanisms
+         */
+        put("SHA1", PKCS11Constants.CKM_SHA_1);
+        put("SHA256", PKCS11Constants.CKM_SHA256);
+        put("SHA384", PKCS11Constants.CKM_SHA384);
+        put("SHA512", PKCS11Constants.CKM_SHA512);
+        put("MD2", PKCS11Constants.CKM_MD2);
+        put("MD5", PKCS11Constants.CKM_MD5);
+        put("RipeMd128", PKCS11Constants.CKM_RIPEMD128);
+        put("RipeMd160", PKCS11Constants.CKM_RIPEMD160);
+    }};
+
+    private static HashMap<Long, String> parameterRequiredMechanisms = new HashMap<Long, String>() {{
+        put(PKCS11Constants.CKM_AES_CBC, "IV16");
+        put(PKCS11Constants.CKM_AES_CBC_PAD, "IV16");
+        put(PKCS11Constants.CKM_AES_GCM, "GCM");
+
+        put(PKCS11Constants.CKM_RSA_PKCS_OAEP, "OAEP");
+
+        put(PKCS11Constants.CKM_DES3_CBC, "IV8");
+        put(PKCS11Constants.CKM_DES3_CBC_PAD, "IV8");
+
+        put(PKCS11Constants.CKM_DES_CBC, "IV8");
+        put(PKCS11Constants.CKM_DES_CBC_PAD, "IV8");
+
+        put(PKCS11Constants.CKM_BLOWFISH_CBC, "IV8");
+
+        put(PKCS11Constants.CKM_SHA1_RSA_PKCS_PSS, "PSS");
+        put(PKCS11Constants.CKM_SHA256_RSA_PKCS_PSS, "PSS");
+        put(PKCS11Constants.CKM_SHA384_RSA_PKCS_PSS, "PSS");
+        put(PKCS11Constants.CKM_SHA512_RSA_PKCS_PSS, "PSS");
+    }};
+
+    protected MechanismResolver() {
+
+    }
+
+    /**
+     * Singleton design pattern is used. Only one instance of Mechanism resolver is used for mechanism resolving.
+     *
+     * @return {@link MechanismResolver} default instance.
+     */
+    public static MechanismResolver getInstance() {
+
+        return defaultMechanismResolver;
+    }
+
+    /**
+     * Method to retrieve of mechanisms.
+     *
+     * @return HashMap of mechanisms.
+     */
+    public static HashMap<String, Long> getSupportedMechanisms() {
+
+        return mechanisms;
+    }
+
+    /**
+     * Method to resolve the PKCS #11 mechanism when JCE mechanism specification is given.
+     *
+     * @param mechanismDataHolder : Holds required data to resolve the mechanism with required parameters.
+     * @return : Properly configured mechanism.
+     */
+    public Mechanism resolveMechanism(MechanismDataHolder mechanismDataHolder) throws CryptoException {
+
+        if (mechanisms.containsKey(mechanismDataHolder.getJceMechanismSpecification())) {
+            logDebug(String.format("Resolving PKCS #11 mechanism for '%s' JCE standard algorithm.",
+                    mechanismDataHolder.getJceMechanismSpecification()));
+            Mechanism mechanism = Mechanism.get(mechanisms.get(mechanismDataHolder.getJceMechanismSpecification()));
+            if (parameterRequiredMechanisms.containsKey(mechanism.getMechanismCode())) {
+                resolveParameters(mechanism, mechanismDataHolder);
+            }
+            logDebug(String.format("Successfully resolved PKCS #11 mechanism for '%s' JCE standard algorithm.",
+                    mechanismDataHolder.getJceMechanismSpecification()));
+            return mechanism;
+        } else {
+            String errorMessage = String.format("Requested %s algorithm is not supported by HSM based crypto provider.",
+                    mechanismDataHolder.getJceMechanismSpecification());
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected void resolveParameters(Mechanism mechanism, MechanismDataHolder mechanismDataHolder)
+            throws CryptoException {
+
+        String parameterSpec = parameterRequiredMechanisms.get(mechanism.getMechanismCode());
+        if (parameterSpec.equals("OAEP")) {
+            String[] specification = mechanismDataHolder.getJceMechanismSpecification().split("/");
+            mechanism.setParameters(getOAEPParameters(specification[specification.length - 1]));
+        } else if (parameterSpec.equals("PSS")) {
+            mechanism.setParameters(getRSAPSSParameters(mechanismDataHolder.getJceMechanismSpecification()));
+        } else if (parameterSpec.startsWith("IV")) {
+            int ivSize = Integer.parseInt(parameterSpec.substring(2, parameterSpec.length()));
+            mechanism.setParameters(getInitializationVectorParameters((IvParameterSpec) mechanismDataHolder
+                    .getAlgorithmParameterSpec(), mechanismDataHolder.getOperatingMode(), ivSize));
+        } else if (parameterSpec.startsWith("GCM")) {
+            mechanism.setParameters(getGCMParameters((GCMParameterSpec) mechanismDataHolder.getAlgorithmParameterSpec(),
+                    mechanismDataHolder.getOperatingMode(), 12, mechanismDataHolder.getAuthData()));
+        }
+        logDebug(String.format("Successfully resolved parameters for '%s' PKCS #11 mechanism.", mechanism.getName()));
+    }
+
+    protected RSAPkcsOaepParameters getOAEPParameters(String parameter) throws CryptoException {
+
+        logDebug(String.format("Resolving RSA OAEP algorithm parameters."));
+        String[] specParams = parameter.split("with");
+        String[] oaepParams = specParams[1].split("and");
+        if (mechanisms.containsKey(oaepParams[0])) {
+            return new RSAPkcsOaepParameters(Mechanism.get(mechanisms.get(oaepParams[0])), 1L,
+                    PKCS11Constants.CKZ_DATA_SPECIFIED, null);
+        } else {
+            String errorMessage = String.format("Invalid '%s' OAEP parameter specification", parameter);
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected RSAPkcsPssParameters getRSAPSSParameters(String algorithmSpecification) throws CryptoException {
+
+        logDebug(String.format("Resolving RSA PSS algorithm parameters for %s algorithm.",
+                algorithmSpecification));
+        if (algorithmSpecification.contains("SHA1")) {
+            return new RSAPkcsPssParameters(Mechanism.get(mechanisms.get("SHA1")), 1L,
+                    20L);
+        } else if (algorithmSpecification.contains("SHA256")) {
+            return new RSAPkcsPssParameters(Mechanism.get(mechanisms.get("SHA256")), 1L,
+                    32L);
+        } else if (algorithmSpecification.contains("SHA384")) {
+            return new RSAPkcsPssParameters(Mechanism.get(mechanisms.get("SHA384")), 1L,
+                    48L);
+        } else if (algorithmSpecification.contains("SHA512")) {
+            return new RSAPkcsPssParameters(Mechanism.get(mechanisms.get("SHA512")), 1L,
+                    64L);
+        } else {
+            String errorMessage = String.format("Invalid '%s' algorithm specification", algorithmSpecification);
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected InitializationVectorParameters getInitializationVectorParameters(IvParameterSpec ivParameterSpec,
+                                                                               int operatingMode, int ivSize)
+            throws CryptoException {
+
+        logDebug("Resolving initialization vector parameters.");
+        if (operatingMode == ENCRYPT_MODE) {
+            return new InitializationVectorParameters(generateIV(ivSize));
+        } else if (operatingMode == DECRYPT_MODE) {
+            if (ivParameterSpec != null) {
+                return new InitializationVectorParameters(ivParameterSpec.getIV());
+            } else {
+                String errorMessage = "Initialization vector parameters can't be null";
+                throw new CryptoException(errorMessage);
+            }
+        } else {
+            String errorMessage = "IV vectors are not defined for sign/verify operating modes.";
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected GcmParameters getGCMParameters(GCMParameterSpec gcmParameterSpec, int operatingMode, int ivSize,
+                                             byte[] authData) throws CryptoException {
+
+        logDebug("Resolving GCM parameters.");
+        if (operatingMode == ENCRYPT_MODE) {
+            return new GcmParameters(generateIV(ivSize), authData, 128);
+        } else if (operatingMode == DECRYPT_MODE) {
+            if (gcmParameterSpec != null) {
+                return new GcmParameters(gcmParameterSpec.getIV(), authData, gcmParameterSpec.getTLen());
+            } else {
+                String errorMessage = "GCM Parameters can't be null.";
+                throw new CryptoException(errorMessage);
+            }
+        } else {
+            String errorMessage = "Invalid mode of operation is requested.";
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected byte[] generateIV(int size) {
+
+        byte[] iv = new byte[size];
+        random.nextBytes(iv);
+        return iv;
+    }
+
+    protected void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/SessionHandler.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/SessionHandler.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import iaik.pkcs.pkcs11.Module;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.Slot;
+import iaik.pkcs.pkcs11.Token;
+import iaik.pkcs.pkcs11.TokenException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+/**
+ * This class is responsible for handling sessions between application and the HSM.
+ */
+public class SessionHandler {
+
+    private static final String PKCS11_MODULE_PROPERTY_PATH =
+            "CryptoService.HSMBasedCryptoProviderConfig.HSMConfiguration.PKCS11Module";
+    private static Log log = LogFactory.getLog(SessionHandler.class);
+    private static SessionHandler sessionHandler;
+
+    private Slot[] slotsWithTokens;
+    private Module pkcs11Module;
+    private ServerConfigurationService serverConfigurationService;
+    private HashMap<Integer, String> configuredSlots;
+
+    protected SessionHandler(ServerConfigurationService serverConfigurationService) throws CryptoException {
+
+        String pkcs11ModulePath = serverConfigurationService.getFirstProperty(PKCS11_MODULE_PROPERTY_PATH);
+        try {
+            pkcs11Module = Module.getInstance(pkcs11ModulePath);
+            pkcs11Module.initialize(null);
+            if (log.isDebugEnabled()) {
+                log.debug("PKCS #11 module successfully initialized.");
+            }
+        } catch (IOException e) {
+            String errorMessage = String.format("Unable to locate PKCS #11 Module in path '%s'.", pkcs11ModulePath);
+            throw new CryptoException(errorMessage, e);
+        } catch (TokenException e) {
+            String errorMessage = "PKCS #11 Module initialization failed.";
+            throw new HSMCryptoException(errorMessage, e);
+        }
+        this.serverConfigurationService = serverConfigurationService;
+        configuredSlots = new HashMap<Integer, String>();
+        setupSlotConfiguration();
+    }
+
+    /**
+     * Singleton design pattern is used. Only one instance of {@link SessionHandler} is used.
+     *
+     * @param serverConfigurationService : Service to read carbon.xml configurations.
+     * @return Default instance of SessionHandler.
+     * @throws CryptoException
+     */
+    public static SessionHandler getDefaultSessionHandler(ServerConfigurationService serverConfigurationService)
+            throws CryptoException {
+
+        synchronized (SessionHandler.class) {
+            if (sessionHandler == null) {
+                sessionHandler = new SessionHandler(serverConfigurationService);
+                if (log.isDebugEnabled()) {
+                    log.debug("Default SessionHandler instance successfully instantiated.");
+                }
+            }
+        }
+        return sessionHandler;
+    }
+
+    /**
+     * Initiate a session for a given slot.
+     *
+     * @param slotNo : Slot number of the required session
+     * @return Instance of a Session.
+     * @throws CryptoException
+     */
+    public Session initiateSession(int slotNo, String slotPIN, boolean readWriteSession) throws CryptoException {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("A session initiation request for slot id : %d.", slotNo));
+        }
+        if (slotsWithTokens == null) {
+            try {
+                slotsWithTokens = pkcs11Module.getSlotList(Module.SlotRequirement.TOKEN_PRESENT);
+                if (log.isDebugEnabled()) {
+                    log.debug("List of slots with tokens successfully retrieved from the PKCS #11 module.");
+                }
+            } catch (TokenException e) {
+                String errorMessage = String.format("Failed to retrieve slots with tokens.");
+                throw new HSMCryptoException(errorMessage, e);
+            }
+        }
+        if (slotsWithTokens.length > slotNo) {
+            Slot slot = slotsWithTokens[slotNo];
+            try {
+                Token token = slot.getToken();
+                Session session = token.openSession(Token.SessionType.SERIAL_SESSION,
+                        readWriteSession, null, null);
+                if (slotPIN == null) {
+                    session.login(Session.UserType.USER, getUserPIN(slotNo));
+                } else {
+                    session.login(Session.UserType.USER, slotPIN.toCharArray());
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug(String.format("A session was initiated for slot id : %d.", slotNo));
+                }
+                return session;
+            } catch (TokenException e) {
+                String errorMessage = String.format("Session initiation failed for slot id : '%d'.", slotNo);
+                throw new HSMCryptoException(errorMessage, e);
+            }
+        } else {
+            String errorMessage = String.format("Slot '%d' is not configured for cryptographic operations.", slotNo);
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    /**
+     * Close the given session.
+     *
+     * @param session : Session that need to be closed.
+     * @throws CryptoException
+     */
+    public void closeSession(Session session) throws CryptoException {
+
+        if (session != null) {
+            try {
+                session.closeSession();
+            } catch (TokenException e) {
+                String errorMessage = "Error occurred during session termination.";
+                throw new HSMCryptoException(errorMessage, e);
+            }
+        }
+    }
+
+    protected char[] getUserPIN(int slotID) throws CryptoException {
+
+        if (configuredSlots.containsKey(slotID)) {
+            return configuredSlots.get(slotID).toCharArray();
+        } else {
+            String errorMessage = String.format("Unable to retrieve slot configuration information for slot id " +
+                    "'%d'.", slotID);
+            throw new CryptoException(errorMessage);
+        }
+    }
+
+    protected void setupSlotConfiguration() throws CryptoException {
+
+        NodeList configuredSlotsCandidateNodes = serverConfigurationService.getDocumentElement().
+                getElementsByTagName("SlotConfiguration");
+        if (configuredSlotsCandidateNodes != null) {
+            Node hsmSlotConfiguration = configuredSlotsCandidateNodes.item(0);
+            NodeList configuredSlots = hsmSlotConfiguration.getChildNodes();
+            for (int i = 0; i < configuredSlots.getLength(); i++) {
+                Node configuredSlot = configuredSlots.item(i);
+                if (configuredSlot.getNodeType() == Node.ELEMENT_NODE && StringUtils.equals("Slot",
+                        configuredSlot.getNodeName())) {
+                    NamedNodeMap attributes = configuredSlot.getAttributes();
+                    int id = Integer.parseInt(attributes.getNamedItem("id").getTextContent());
+                    String pin = attributes.getNamedItem("pin").getTextContent();
+                    if (!this.configuredSlots.containsKey(id)) {
+                        this.configuredSlots.put(id, pin);
+                    }
+                }
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully retrieved slot configuration information from carbon.xml.");
+            }
+        } else {
+            String errorMessage = "Unable to retrieve slot configuration information.";
+            throw new CryptoException(errorMessage);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/internal/HSMCryptoImplComponent.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/internal/HSMCryptoImplComponent.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.internal;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.api.ExternalCryptoProvider;
+import org.wso2.carbon.crypto.api.InternalCryptoProvider;
+import org.wso2.carbon.crypto.api.KeyResolver;
+import org.wso2.carbon.crypto.provider.hsm.HSMBasedExternalCryptoProvider;
+import org.wso2.carbon.crypto.provider.hsm.HSMBasedInternalCryptoProvider;
+import org.wso2.carbon.crypto.provider.hsm.HSMBasedKeyResolver;
+
+/**
+ * The class which is used to deal with the OSGi runtime for service registration and injection.
+ */
+@Component(
+        name = "org.wso2.carbon.crypto.provider.hsm",
+        immediate = true
+)
+public class HSMCryptoImplComponent {
+
+    private static final Log log = LogFactory.getLog(HSMCryptoImplComponent.class);
+    private static final String CRYPTO_SERVICE_ENABLING_PROPERTY_PATH = "CryptoService.Enabled";
+
+    private ServiceRegistration<ExternalCryptoProvider> hsmBasedExternalCryptoProviderServiceRegistration;
+    private ServiceRegistration<InternalCryptoProvider> hsmBasedInternalCryptoProviderServiceRegistration;
+    private ServiceRegistration<KeyResolver> hsmBasedKeyResolverServiceRegistration;
+    private ServerConfigurationService serverConfigurationService;
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        if (!isCryptoServiceEnabled()) {
+            if (log.isDebugEnabled()) {
+                log.debug("CryptoService is not enabled.");
+            }
+            return;
+        }
+
+        try {
+            BundleContext bundleContext = context.getBundleContext();
+            registerProviderImplementations(bundleContext);
+        } catch (Throwable e) {
+            String errorMessage = "An error occurred while activating HSM based crypto provider.";
+            log.error(errorMessage, e);
+        }
+
+        if (log.isInfoEnabled()) {
+            log.info("HSM Based crypto provider has been activated successfully.");
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+
+        hsmBasedExternalCryptoProviderServiceRegistration.unregister();
+        hsmBasedInternalCryptoProviderServiceRegistration.unregister();
+        hsmBasedKeyResolverServiceRegistration.unregister();
+    }
+
+    @Reference(
+            name = "serverConfigurationService",
+            service = ServerConfigurationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            unbind = "unsetServerConfigurationService"
+    )
+    protected void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    protected void unsetServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        this.serverConfigurationService = null;
+    }
+
+    protected boolean isCryptoServiceEnabled() {
+
+        String enabled = serverConfigurationService.getFirstProperty(CRYPTO_SERVICE_ENABLING_PROPERTY_PATH);
+        if (!StringUtils.isBlank(enabled)) {
+            return Boolean.parseBoolean(enabled);
+        }
+        return false;
+    }
+
+    protected void registerProviderImplementations(BundleContext bundleContext) throws CryptoException {
+
+        ExternalCryptoProvider hsmBasedExternalCryptoProvider = getHSMBasedExternalCryptoProvider();
+
+        InternalCryptoProvider hsmBasedInternalCryptoProvider = getHSMBasedInternalCryptoProvider();
+
+        KeyResolver hsmBasedKeyResolver = getHSMBasedKeyResolver();
+
+        hsmBasedExternalCryptoProviderServiceRegistration = bundleContext.
+                registerService(ExternalCryptoProvider.class, hsmBasedExternalCryptoProvider, null);
+        String infoMessage = "'%s' has been registered successfully.";
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(infoMessage, "HSMBasedExternalCryptoProvider"));
+        }
+
+        hsmBasedInternalCryptoProviderServiceRegistration = bundleContext.
+                registerService(InternalCryptoProvider.class, hsmBasedInternalCryptoProvider, null);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(infoMessage, "HSMBasedInternalCryptoProvider"));
+        }
+
+        hsmBasedKeyResolverServiceRegistration = bundleContext.
+                registerService(KeyResolver.class, hsmBasedKeyResolver, null);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(infoMessage, "HSMBasedKeyResolver"));
+        }
+    }
+
+    protected HSMBasedExternalCryptoProvider getHSMBasedExternalCryptoProvider() throws CryptoException {
+
+        HSMBasedExternalCryptoProvider hsmBasedExternalCryptoProvider =
+                new HSMBasedExternalCryptoProvider(this.serverConfigurationService);
+        return hsmBasedExternalCryptoProvider;
+    }
+
+    protected HSMBasedInternalCryptoProvider getHSMBasedInternalCryptoProvider() throws CryptoException {
+
+        HSMBasedInternalCryptoProvider hsmBasedInternalCryptoProvider =
+                new HSMBasedInternalCryptoProvider(this.serverConfigurationService);
+        return hsmBasedInternalCryptoProvider;
+    }
+
+    protected HSMBasedKeyResolver getHSMBasedKeyResolver() {
+
+        HSMBasedKeyResolver hsmBasedKeyResolver = new HSMBasedKeyResolver(this.serverConfigurationService);
+        return hsmBasedKeyResolver;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/internal/HSMCryptoImplComponent.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/internal/HSMCryptoImplComponent.java
@@ -37,6 +37,8 @@ import org.wso2.carbon.crypto.api.KeyResolver;
 import org.wso2.carbon.crypto.provider.hsm.HSMBasedExternalCryptoProvider;
 import org.wso2.carbon.crypto.provider.hsm.HSMBasedInternalCryptoProvider;
 import org.wso2.carbon.crypto.provider.hsm.HSMBasedKeyResolver;
+import org.wso2.carbon.crypto.provider.hsm.storemanager.DefaultHSMStoreManagerServiceImpl;
+import org.wso2.carbon.crypto.provider.hsm.storemanager.HSMStoreManagerService;
 
 /**
  * The class which is used to deal with the OSGi runtime for service registration and injection.
@@ -53,6 +55,7 @@ public class HSMCryptoImplComponent {
     private ServiceRegistration<ExternalCryptoProvider> hsmBasedExternalCryptoProviderServiceRegistration;
     private ServiceRegistration<InternalCryptoProvider> hsmBasedInternalCryptoProviderServiceRegistration;
     private ServiceRegistration<KeyResolver> hsmBasedKeyResolverServiceRegistration;
+    private ServiceRegistration<HSMStoreManagerService> hsmStoreManagerServiceServiceRegistration;
     private ServerConfigurationService serverConfigurationService;
 
     @Activate
@@ -84,6 +87,7 @@ public class HSMCryptoImplComponent {
         hsmBasedExternalCryptoProviderServiceRegistration.unregister();
         hsmBasedInternalCryptoProviderServiceRegistration.unregister();
         hsmBasedKeyResolverServiceRegistration.unregister();
+        hsmStoreManagerServiceServiceRegistration.unregister();
     }
 
     @Reference(
@@ -138,6 +142,13 @@ public class HSMCryptoImplComponent {
 
         if (log.isDebugEnabled()) {
             log.debug(String.format(infoMessage, "HSMBasedKeyResolver"));
+        }
+
+        hsmStoreManagerServiceServiceRegistration = bundleContext.registerService(HSMStoreManagerService.class,
+                new DefaultHSMStoreManagerServiceImpl(serverConfigurationService), null);
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format(infoMessage, "DefaultHSMStoreManagerService"));
         }
     }
 

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/storemanager/DefaultHSMStoreManagerServiceImpl.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/storemanager/DefaultHSMStoreManagerServiceImpl.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.storemanager;
+
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.PKCS11CertificateData;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.CertificateHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+/**
+ * Default implementation of {@link HSMStoreManagerService}.
+ */
+public class DefaultHSMStoreManagerServiceImpl implements HSMStoreManagerService {
+
+    private static final String EXTERNAL_PROVIDER_SLOT_PROPERTY_PATH =
+            "CryptoService.HSMBasedCryptoProviderConfig.ExternalProvider.ExternalProviderSlotID";
+
+    private static Log log = LogFactory.getLog(DefaultHSMStoreManagerServiceImpl.class);
+
+    private SessionHandler sessionHandler;
+    private ServerConfigurationService serverConfigurationService;
+
+    /**
+     * Constructor of default HSM store manager service.
+     *
+     * @param serverConfigurationService : carbon.xml configuration as a service.
+     * @throws CryptoException
+     */
+    public DefaultHSMStoreManagerServiceImpl(ServerConfigurationService serverConfigurationService)
+            throws CryptoException {
+
+        this.sessionHandler = SessionHandler.getDefaultSessionHandler(serverConfigurationService);
+        this.serverConfigurationService = serverConfigurationService;
+    }
+
+    /**
+     * This stores a given private key in the HSM's external provider slot.
+     *
+     * @param privateKey : PKCS #11 private key to be stored.
+     * @throws CryptoException
+     */
+    @Override
+    public void storePrivateKey(PrivateKey privateKey) throws CryptoException {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Storing the private key with %s alias in HSM's external provider slot.",
+                    new String(privateKey.getLabel().getCharArrayValue())));
+        }
+        Session session = initiateSession();
+        try {
+            KeyHandler keyHandler = new KeyHandler(session);
+            keyHandler.storeKey(privateKey);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Successfully stored the certificate with %s alias in HSM's external provider " +
+                        "slot.", new String(privateKey.getLabel().getCharArrayValue())));
+            }
+        } finally {
+            if (session != null) {
+                sessionHandler.closeSession(session);
+            }
+        }
+    }
+
+    /**
+     * This stores a given certificate in the HSM's external provider slot.
+     *
+     * @param certificate : PKCS #11 certificate and public key to be stored.
+     * @throws CryptoException
+     */
+    @Override
+    public void storeCertificate(PKCS11CertificateData certificate) throws CryptoException {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Storing the certificate with %s alias in HSM's external provider slot.",
+                    new String(certificate.getCertificate().getLabel().getCharArrayValue())));
+        }
+        Session session = initiateSession();
+        try {
+            CertificateHandler certificateHandler = new CertificateHandler(session);
+            certificateHandler.storeCertificate(certificate.getCertificate());
+            KeyHandler keyHandler = new KeyHandler(session);
+            keyHandler.storeKey(certificate.getPublicKey());
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Successfully stored the certificate with %s alias in HSM's external provider " +
+                        "slot.", new String(certificate.getCertificate().getLabel().getCharArrayValue())));
+            }
+        } finally {
+            if (session != null) {
+                sessionHandler.closeSession(session);
+            }
+        }
+
+    }
+
+    protected Session initiateSession() throws CryptoException {
+
+        return sessionHandler.initiateSession(Integer.parseInt(serverConfigurationService
+                .getFirstProperty(EXTERNAL_PROVIDER_SLOT_PROPERTY_PATH)), null, true);
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/storemanager/HSMStoreManagerService.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/main/java/org/wso2/carbon/crypto/provider/hsm/storemanager/HSMStoreManagerService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.storemanager;
+
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.PKCS11CertificateData;
+
+/**
+ * This service provides capabilities to store certificates and private keys in the HSM device.
+ */
+public interface HSMStoreManagerService {
+
+    /**
+     * Store a PKCS #11 private key in the HSM device.
+     *
+     * @param privateKey
+     * @throws CryptoException
+     */
+    void storePrivateKey(PrivateKey privateKey) throws CryptoException;
+
+    /**
+     * Store a PKCS #11 certifcate and public key in the HSM device.
+     *
+     * @param certificate
+     * @throws CryptoException
+     */
+    void storeCertificate(PKCS11CertificateData certificate) throws CryptoException;
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedExternalCryptoProviderTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedExternalCryptoProviderTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.crypto.api.CertificateInfo;
+import org.wso2.carbon.crypto.api.CryptoContext;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.api.HybridEncryptionInput;
+import org.wso2.carbon.crypto.api.HybridEncryptionOutput;
+import org.wso2.carbon.crypto.api.PrivateKeyInfo;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolver;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+
+public class HSMBasedExternalCryptoProviderTest {
+
+    private HSMBasedExternalCryptoProvider hsmBasedExternalCryptoProvider;
+    private HSMBasedKeyResolver hsmBasedKeyResolver;
+    private ArrayList<CryptoContext> sampleCryptoContexts = new ArrayList<>();
+    private ArrayList<byte[]> sampleData = new ArrayList<>();
+    private ArrayList<byte[]> sampleSignatures = new ArrayList<>();
+    private ArrayList<byte[]> sampleEncryptedData = new ArrayList<>();
+    private ArrayList<HybridEncryptionInput> sampleHybridEncryptionInputs = new ArrayList<>();
+    private ArrayList<HybridEncryptionOutput> sampleHybridEncryptedData = new ArrayList<>();
+
+    @BeforeClass
+    public void setUpClass() throws ServerConfigurationException, CryptoException {
+
+        hsmBasedKeyResolver = new HSMBasedKeyResolver(TestUtil.getServerConfigurationService());
+        hsmBasedExternalCryptoProvider = new HSMBasedExternalCryptoProvider(TestUtil.getServerConfigurationService());
+    }
+
+    @Test(dataProvider = "sampleSignDataProvider")
+    public void testSign(byte[] data, String algorithm, String javaSecurityAPIProvider, CryptoContext cryptoContext,
+                         PrivateKeyInfo privateKeyInfo) {
+
+        try {
+            byte[] signature = hsmBasedExternalCryptoProvider
+                    .sign(data, algorithm, javaSecurityAPIProvider, cryptoContext, privateKeyInfo);
+            sampleSignatures.add(signature);
+        } catch (CryptoException e) {
+            if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+                Assert.assertEquals(e.getMessage(),
+                        String.format("Requested algorithm '%s' is not valid/supported.", algorithm));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleSignDataProvider")
+    public Object[][] getSignData() {
+
+        sampleData.add("Sample 1 for testing".getBytes());
+        sampleData.add(new byte[1000]);
+        sampleData.add("".getBytes());
+        sampleData.add(null);
+
+        sampleCryptoContexts.add(CryptoContext.buildEmptyContext(-1234, "carbon.super"));
+        sampleCryptoContexts.add((CryptoContext.buildEmptyContext(1, "abc.com")));
+        sampleCryptoContexts.add(null);
+
+        return new Object[][]{
+                {
+                        sampleData.get(0), "SHA1withRSAandMGF1", null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+
+                },
+                {
+                        sampleData.get(1), "SHA384withRSAandMGF1", null, sampleCryptoContexts.get(1),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(1))
+
+                },
+                {
+                        sampleData.get(2), "SHA384withRSA", null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+
+                },
+                {
+                        sampleData.get(3), "MD5withRSA", null, sampleCryptoContexts.get(2),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleData.get(0), "SHA132", null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleDecryptDataProvider", priority = 2)
+    public void testDecrypt(byte[] ciphertext, String algorithm, String javaSecurityAPIProvider,
+                            CryptoContext cryptoContext, PrivateKeyInfo privateKeyInfo, byte[] expectedDecryptData) {
+
+        try {
+            byte[] decrytpedData = hsmBasedExternalCryptoProvider.decrypt(ciphertext, algorithm,
+                    javaSecurityAPIProvider, cryptoContext, privateKeyInfo);
+            Assert.assertEquals(decrytpedData, expectedDecryptData);
+        } catch (CryptoException e) {
+            if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+                Assert.assertEquals(e.getMessage(),
+                        String.format("Requested algorithm '%s' is not valid/supported.", algorithm));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleDecryptDataProvider")
+    public Object[][] getDecryptSampleData() {
+
+        return new Object[][]{
+                {
+                        sampleEncryptedData.get(0), "RSA/ECB/PKCS1Padding", null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(0)
+                },
+                {
+                        sampleEncryptedData.get(1), "RSA/ECB/OAEPwithSHA384andMGF1Padding", null, sampleCryptoContexts.get(1),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(1)), sampleData.get(1)
+                },
+                {
+                        sampleEncryptedData.get(2), "RSA/ECB/OAEPwithSHA1andMGF1Padding", null, sampleCryptoContexts.get(2),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(2)
+                },
+                {
+                        sampleEncryptedData.get(3), null, null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(3)
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleEncryptDataProvider", priority = 1)
+    public void testEncrypt(byte[] data, String algorithm, String javaSecurityAPIProvider,
+                            CryptoContext cryptoContext, CertificateInfo certificateInfo) {
+
+        try {
+            byte[] encryptedData = hsmBasedExternalCryptoProvider
+                    .encrypt(data, algorithm, javaSecurityAPIProvider, cryptoContext, certificateInfo);
+            sampleEncryptedData.add(encryptedData);
+        } catch (CryptoException e) {
+            if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+                Assert.assertEquals(e.getMessage(),
+                        String.format("Requested algorithm '%s' is not valid/supported.", algorithm));
+            }
+            sampleEncryptedData.add(null);
+        }
+    }
+
+    @DataProvider(name = "sampleEncryptDataProvider")
+    public Object[][] getEncryptSampleData() {
+
+        return new Object[][]{
+                {
+                        sampleData.get(0), "RSA/ECB/PKCS1Padding", null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleData.get(1), "RSA/ECB/OAEPwithSHA384andMGF1Padding", null, sampleCryptoContexts.get(1),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(1))
+                },
+                {
+                        sampleData.get(2), "RSA/ECB/OAEPwithSHA1andMGF1Padding", null, sampleCryptoContexts.get(2),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleData.get(3), null, null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleVerifyDataProvider", priority = 2)
+    public void testVerifySignature(byte[] data, byte[] signature, String algorithm, String javaSecurityAPIProvider,
+                                    CryptoContext cryptoContext, CertificateInfo certificateInfo,
+                                    boolean expectedResult) {
+
+        try {
+            boolean verification = hsmBasedExternalCryptoProvider.verifySignature(data, signature, algorithm,
+                    javaSecurityAPIProvider, cryptoContext, certificateInfo);
+            Assert.assertEquals(verification, expectedResult);
+        } catch (CryptoException e) {
+            if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+                Assert.assertEquals(e.getMessage(),
+                        String.format("Requested algorithm '%s' is not valid/supported.", algorithm));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleVerifyDataProvider")
+    public Object[][] getSampleVerifyData() {
+
+        return new Object[][]{
+                {
+                        sampleData.get(0), sampleSignatures.get(0), "SHA1withRSAandMGF1", null, sampleCryptoContexts
+                        .get(0), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0)), true
+
+                },
+                {
+                        sampleData.get(1), sampleSignatures.get(1), "SHA384withRSAandMGF1", null, sampleCryptoContexts
+                        .get(1), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(1)), true
+
+                },
+                {
+                        sampleData.get(2), sampleSignatures.get(0), "SHA384withRSA", null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0)), false
+
+                },
+                {
+                        sampleData.get(3), sampleSignatures.get(3), "MD5withRSA", null, sampleCryptoContexts.get(2),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0)), true
+                },
+                {
+                        sampleData.get(0), sampleSignatures.get(0), null, null, sampleCryptoContexts.get(0),
+                        hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0)), true
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleCertificateDataProvider", priority = 1)
+    public void testGetCertificate(CryptoContext cryptoContext, CertificateInfo certificateInfo) {
+
+        try {
+            X509Certificate certificate = (X509Certificate) hsmBasedExternalCryptoProvider
+                    .getCertificate(cryptoContext, certificateInfo);
+            Assert.assertNotNull(certificate);
+        } catch (CryptoException e) {
+            if (cryptoContext == null) {
+                Assert.assertEquals(e.getMessage(), "Tenant information is missing in the crypto context.");
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleCertificateDataProvider")
+    public Object[][] getSampleCertificateData() {
+
+        return new Object[][]{
+                {
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleCryptoContexts.get(1), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(1))
+                },
+                {
+                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                }
+        };
+    }
+
+    @Test(dataProvider = "samplePrivateKeyDataProvider", priority = 1)
+    public void testGetPrivateKey(CryptoContext cryptoContext, PrivateKeyInfo privateKeyInfo) {
+
+        try {
+            PrivateKey retrievedKey = hsmBasedExternalCryptoProvider.getPrivateKey(cryptoContext, privateKeyInfo);
+            Assert.assertNotNull(retrievedKey);
+        } catch (CryptoException e) {
+            if (cryptoContext == null) {
+                Assert.assertEquals(e.getMessage(), "Tenant information is missing in the crypto context.");
+            }
+        }
+    }
+
+    @DataProvider(name = "samplePrivateKeyDataProvider")
+    public Object[][] getSamplePrivateKeyData() {
+
+        CryptoContext sampleContext1 = CryptoContext.buildEmptyContext(2, "def.com");
+        CryptoContext sampleContext2 = CryptoContext.buildEmptyContext(3, "sample.com");
+
+        return new Object[][]{
+                {
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleCryptoContexts.get(1), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(1))
+                },
+                {
+                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleContext1, hsmBasedKeyResolver.getPrivateKeyInfo(sampleContext1)
+                },
+                {
+                        sampleContext2, hsmBasedKeyResolver.getPrivateKeyInfo(sampleContext2)
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleHybridEncryptDataProvider", priority = 1)
+    public void testHybridEncrypt(HybridEncryptionInput hybridEncryptionInput, String symmetricAlgorithm,
+                                  String asymmetricAlgorithm, String javaSecurityProvider,
+                                  CryptoContext cryptoContext, CertificateInfo certificateInfo) throws CryptoException {
+
+        HybridEncryptionOutput hybridEncryptionOutput = hsmBasedExternalCryptoProvider.hybridEncrypt(
+                hybridEncryptionInput, symmetricAlgorithm, asymmetricAlgorithm, javaSecurityProvider,
+                cryptoContext, certificateInfo);
+        sampleHybridEncryptedData.add(hybridEncryptionOutput);
+    }
+
+    @DataProvider(name = "sampleHybridEncryptDataProvider")
+    public Object[][] getSampleHybridEncryptData() {
+
+        sampleHybridEncryptionInputs.add(new HybridEncryptionInput(sampleData.get(0), new byte[20]));
+        sampleHybridEncryptionInputs.add(new HybridEncryptionInput(sampleData.get(1)));
+        sampleHybridEncryptionInputs.add(new HybridEncryptionInput(sampleData.get(2), new byte[10]));
+        sampleHybridEncryptionInputs.add(new HybridEncryptionInput(sampleData.get(0)));
+
+        return new Object[][]{
+                {
+                        sampleHybridEncryptionInputs.get(0), "AES_192/GCM/NoPadding", "RSA/ECB/OAEPwithSHA1andMGF1Padding", null,
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleHybridEncryptionInputs.get(1), "AES_256/CBC/PKCS5Padding", "RSA/ECB/PKCS1Padding", null,
+                        sampleCryptoContexts.get(1), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(1))
+                },
+                {
+                        sampleHybridEncryptionInputs.get(2), "DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithMD5andMGF1Padding", null,
+                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                },
+                {
+                        sampleHybridEncryptionInputs.get(3), "3DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithSHA512andMGF1Padding", null,
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleHybridDecryptDataProvider", priority = 2)
+    public void testHybridDecrypt(HybridEncryptionOutput hybridDecryptionInput, String symmetricAlgorithm,
+                                  String asymmetricAlgorithm, String javaSecurityProvider, CryptoContext cryptoContext,
+                                  PrivateKeyInfo privateKeyInfo, byte[] expectedOutput) throws CryptoException {
+
+        byte[] clearData = hsmBasedExternalCryptoProvider.hybridDecrypt(hybridDecryptionInput,
+                symmetricAlgorithm, asymmetricAlgorithm, javaSecurityProvider, cryptoContext, privateKeyInfo);
+        Assert.assertEquals(clearData, expectedOutput);
+    }
+
+    @DataProvider(name = "sampleHybridDecryptDataProvider")
+    public Object[][] getSampleHybridDecryptData() {
+
+        return new Object[][]{
+                {
+                        sampleHybridEncryptedData.get(0), "AES_192/GCM/NoPadding", "RSA/ECB/OAEPwithSHA1andMGF1Padding", null,
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(0)
+                },
+                {
+                        sampleHybridEncryptedData.get(1), "AES_256/CBC/PKCS5Padding", "RSA/ECB/PKCS1Padding", null,
+                        sampleCryptoContexts.get(1), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(1)), sampleData.get(1)
+                },
+                {
+                        sampleHybridEncryptedData.get(2), "DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithMD5andMGF1Padding", null,
+                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(2)
+                },
+                {
+                        sampleHybridEncryptedData.get(3), "3DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithSHA512andMGF1Padding", null,
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(0)
+                }
+        };
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedExternalCryptoProviderTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedExternalCryptoProviderTest.java
@@ -78,8 +78,7 @@ public class HSMBasedExternalCryptoProviderTest {
         sampleData.add(null);
 
         sampleCryptoContexts.add(CryptoContext.buildEmptyContext(-1234, "carbon.super"));
-        sampleCryptoContexts.add((CryptoContext.buildEmptyContext(1, "abc.com")));
-        sampleCryptoContexts.add(null);
+        sampleCryptoContexts.add((CryptoContext.buildEmptyContext(1, "wso2.lk")));
 
         return new Object[][]{
                 {
@@ -98,7 +97,7 @@ public class HSMBasedExternalCryptoProviderTest {
 
                 },
                 {
-                        sampleData.get(3), "MD5withRSA", null, sampleCryptoContexts.get(2),
+                        sampleData.get(3), "MD5withRSA", null, sampleCryptoContexts.get(0),
                         hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
                 },
                 {
@@ -114,9 +113,9 @@ public class HSMBasedExternalCryptoProviderTest {
                             CryptoContext cryptoContext, PrivateKeyInfo privateKeyInfo, byte[] expectedDecryptData) {
 
         try {
-            byte[] decrytpedData = hsmBasedExternalCryptoProvider.decrypt(ciphertext, algorithm,
+            byte[] decryptedData = hsmBasedExternalCryptoProvider.decrypt(ciphertext, algorithm,
                     javaSecurityAPIProvider, cryptoContext, privateKeyInfo);
-            Assert.assertEquals(decrytpedData, expectedDecryptData);
+            Assert.assertEquals(decryptedData, expectedDecryptData);
         } catch (CryptoException e) {
             if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
                 Assert.assertEquals(e.getMessage(),
@@ -138,7 +137,7 @@ public class HSMBasedExternalCryptoProviderTest {
                         hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(1)), sampleData.get(1)
                 },
                 {
-                        sampleEncryptedData.get(2), "RSA/ECB/OAEPwithSHA1andMGF1Padding", null, sampleCryptoContexts.get(2),
+                        sampleEncryptedData.get(2), "RSA/ECB/OAEPwithSHA1andMGF1Padding", null, sampleCryptoContexts.get(0),
                         hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(2)
                 },
                 {
@@ -178,7 +177,7 @@ public class HSMBasedExternalCryptoProviderTest {
                         hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(1))
                 },
                 {
-                        sampleData.get(2), "RSA/ECB/OAEPwithSHA1andMGF1Padding", null, sampleCryptoContexts.get(2),
+                        sampleData.get(2), "RSA/ECB/OAEPwithSHA1andMGF1Padding", null, sampleCryptoContexts.get(0),
                         hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
                 },
                 {
@@ -225,7 +224,7 @@ public class HSMBasedExternalCryptoProviderTest {
 
                 },
                 {
-                        sampleData.get(3), sampleSignatures.get(3), "MD5withRSA", null, sampleCryptoContexts.get(2),
+                        sampleData.get(3), sampleSignatures.get(3), "MD5withRSA", null, sampleCryptoContexts.get(0),
                         hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0)), true
                 },
                 {
@@ -260,7 +259,7 @@ public class HSMBasedExternalCryptoProviderTest {
                         sampleCryptoContexts.get(1), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(1))
                 },
                 {
-                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
                 }
         };
     }
@@ -292,7 +291,7 @@ public class HSMBasedExternalCryptoProviderTest {
                         sampleCryptoContexts.get(1), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(1))
                 },
                 {
-                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0))
                 },
                 {
                         sampleContext1, hsmBasedKeyResolver.getPrivateKeyInfo(sampleContext1)
@@ -333,7 +332,7 @@ public class HSMBasedExternalCryptoProviderTest {
                 },
                 {
                         sampleHybridEncryptionInputs.get(2), "DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithMD5andMGF1Padding", null,
-                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getCertificateInfo(sampleCryptoContexts.get(0))
                 },
                 {
                         sampleHybridEncryptionInputs.get(3), "3DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithSHA512andMGF1Padding", null,
@@ -366,7 +365,7 @@ public class HSMBasedExternalCryptoProviderTest {
                 },
                 {
                         sampleHybridEncryptedData.get(2), "DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithMD5andMGF1Padding", null,
-                        sampleCryptoContexts.get(2), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(2)
+                        sampleCryptoContexts.get(0), hsmBasedKeyResolver.getPrivateKeyInfo(sampleCryptoContexts.get(0)), sampleData.get(2)
                 },
                 {
                         sampleHybridEncryptedData.get(3), "3DES/CBC/PKCS5Padding", "RSA/ECB/OAEPwithSHA512andMGF1Padding", null,

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedInternalCryptoProviderTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedInternalCryptoProviderTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolver;
+
+import java.util.ArrayList;
+
+public class HSMBasedInternalCryptoProviderTest {
+
+    private HSMBasedInternalCryptoProvider hsmBasedInternalCryptoProvider;
+    private ArrayList<byte[]> samplePlainData = new ArrayList<>();
+    private ArrayList<byte[]> sampleEncryptedData = new ArrayList<>();
+
+    @BeforeClass
+    public void setUpClass() throws ServerConfigurationException, CryptoException {
+
+        hsmBasedInternalCryptoProvider = new HSMBasedInternalCryptoProvider(TestUtil.getServerConfigurationService());
+    }
+
+    @Test(dataProvider = "sampleEncryptionDataProvider")
+    public void testEncrypt(byte[] cleartext, String algorithm, String javaSecurityAPIProvider) {
+
+        try {
+            byte[] encryptedData = hsmBasedInternalCryptoProvider.encrypt(cleartext, algorithm, javaSecurityAPIProvider);
+            sampleEncryptedData.add(encryptedData);
+        } catch (CryptoException e) {
+            if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested algorithm '%s' is not valid/supported by the " +
+                        "HSM based Crypto Provider.", algorithm));
+                sampleEncryptedData.add(cleartext);
+            } else if (cleartext == null || cleartext.length == 0) {
+                Assert.assertEquals(e.getMessage(), "Data sent for cryptographic operation is null/empty.");
+                sampleEncryptedData.add(cleartext);
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleEncryptionDataProvider")
+    public Object[][] getSampleEncryptionData() {
+
+        samplePlainData.add("Sample data to be encrypted using RSA OAEP MD5".getBytes());
+        samplePlainData.add("Sample data to be encrypted using RSA OAEP SHA512".getBytes());
+        samplePlainData.add("".getBytes());
+        samplePlainData.add(null);
+        samplePlainData.add("Invalid algorithm".getBytes());
+
+        return new Object[][]{
+                {
+                        samplePlainData.get(0), "RSA/ECB/OAEPwithMD5andMGF1Padding", null
+                },
+                {
+                        samplePlainData.get(1), "RSA/ECB/OAEPwithSHA512andMGF1Padding", null
+                },
+                {
+                        samplePlainData.get(2), "RSA/ECB/OAEPwithSHA256andMGF1Padding", null
+                },
+                {
+                        samplePlainData.get(3), "RSA/ECB/PKCS1Padding", null
+                },
+                {
+                        samplePlainData.get(4), "InvalidAlgorithm", null
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleDecryptionDataProvider", priority = 1)
+    public void testDecrypt(byte[] ciphertext, String algorithm, String javaSecurityAPIProvider,
+                            byte[] testedSampleData) {
+
+        try {
+            byte[] decryptedData = hsmBasedInternalCryptoProvider.decrypt(ciphertext, algorithm, javaSecurityAPIProvider);
+            Assert.assertEquals(decryptedData, testedSampleData);
+        } catch (CryptoException e) {
+            if (!(algorithm != null && MechanismResolver.getSupportedMechanisms().containsKey(algorithm))) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested algorithm '%s' is not valid/supported by the " +
+                        "HSM based Crypto Provider.", algorithm));
+            } else if (ciphertext == null || ciphertext.length == 0) {
+                Assert.assertEquals(e.getMessage(), "Data sent for cryptographic operation is null/empty.");
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleDecryptionDataProvider")
+    public Object[][] getSampleDecryptionData() {
+
+        return new Object[][]{
+                {
+                        sampleEncryptedData.get(0), "RSA/ECB/OAEPwithMD5andMGF1Padding", null,
+                        samplePlainData.get(0)
+                },
+                {
+                        sampleEncryptedData.get(1), "RSA/ECB/OAEPwithSHA512andMGF1Padding", null,
+                        samplePlainData.get(1)
+                },
+                {
+                        sampleEncryptedData.get(2), "RSA/ECB/OAEPwithSHA256andMGF1Padding", null,
+                        samplePlainData.get(2)
+                },
+                {
+                        sampleEncryptedData.get(3), "RSA/ECB/PKCS1Padding", null, samplePlainData.get(3)
+                },
+                {
+                        sampleEncryptedData.get(4), "InvalidAlgorithm", null, samplePlainData.get(4)
+                }
+        };
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedKeyResolverTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/HSMBasedKeyResolverTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CertificateInfo;
+import org.wso2.carbon.crypto.api.CryptoContext;
+import org.wso2.carbon.crypto.api.PrivateKeyInfo;
+
+import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_ID;
+
+public class HSMBasedKeyResolverTest {
+
+    private static final String PRIMARY_KEYSTORE_KEY_ALIAS_PROPERTY_PATH = "Security.KeyStore.KeyAlias";
+
+    private HSMBasedKeyResolver hsmBasedKeyResolver;
+    private ServerConfigurationService serverConfigurationService;
+
+    @BeforeClass
+    public void setUpClass() throws ServerConfigurationException {
+
+        serverConfigurationService = TestUtil.getServerConfigurationService();
+        hsmBasedKeyResolver = new HSMBasedKeyResolver(serverConfigurationService);
+    }
+
+    @Test(dataProvider = "sampleKeyResolverDataProvider")
+    public void testIsApplicable(CryptoContext cryptoContext) {
+
+        Assert.assertTrue(hsmBasedKeyResolver.isApplicable(cryptoContext));
+    }
+
+    @Test(dataProvider = "sampleKeyResolverDataProvider")
+    public void testGetPrivateKeyInfo(CryptoContext cryptoContext) {
+
+        PrivateKeyInfo privateKeyInfo = hsmBasedKeyResolver.getPrivateKeyInfo(cryptoContext);
+
+        if (SUPER_TENANT_ID == cryptoContext.getTenantId()) {
+            Assert.assertEquals(privateKeyInfo.getKeyAlias(),
+                    serverConfigurationService.getFirstProperty(PRIMARY_KEYSTORE_KEY_ALIAS_PROPERTY_PATH));
+        } else {
+            Assert.assertEquals(privateKeyInfo.getKeyAlias(), cryptoContext.getTenantDomain());
+            Assert.assertNull(privateKeyInfo.getKeyPassword());
+        }
+    }
+
+    @Test(dataProvider = "sampleKeyResolverDataProvider")
+    public void testGetCertificateInfo(CryptoContext cryptoContext) {
+
+        CertificateInfo certificateInfo = hsmBasedKeyResolver.getCertificateInfo(cryptoContext);
+        if (SUPER_TENANT_ID == cryptoContext.getTenantId()) {
+            Assert.assertEquals(certificateInfo.getCertificateAlias(),
+                    serverConfigurationService.getFirstProperty(PRIMARY_KEYSTORE_KEY_ALIAS_PROPERTY_PATH));
+            ;
+        } else {
+            Assert.assertEquals(certificateInfo.getCertificateAlias(), cryptoContext.getTenantDomain());
+        }
+    }
+
+    @DataProvider(name = "sampleKeyResolverDataProvider")
+    public Object[][] getSampleCryptoContexts() {
+
+        return new Object[][]{
+                {
+                        CryptoContext.buildEmptyContext(-1234, "carbon.super")
+                },
+                {
+                        CryptoContext.buildEmptyContext(12, "abc.com")
+                },
+                {
+                        CryptoContext.buildEmptyContext(1231, "def.com")
+                }
+        };
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/TestUtil.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/TestUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm;
+
+import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+import java.io.File;
+
+public class TestUtil {
+
+    private static ServerConfigurationService serverConfigurationService;
+
+    public static ServerConfigurationService getServerConfigurationService() throws ServerConfigurationException {
+
+        synchronized (TestUtil.class) {
+            if (serverConfigurationService == null) {
+                serverConfigurationService = ServerConfiguration.getInstance();
+                System.setProperty("carbon.home", new File("src/test/java/resources/home").getAbsolutePath());
+                ((ServerConfiguration) serverConfigurationService).init(
+                        System.getProperty("carbon.home") + "/repository/conf/carbon.xml");
+            }
+        }
+        return serverConfigurationService;
+    }
+
+    public static SessionHandler getSessionHandler() throws ServerConfigurationException, CryptoException {
+
+        return SessionHandler.getDefaultSessionHandler(getServerConfigurationService());
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/CertificateHandlerTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/CertificateHandlerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers;
+
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.Certificate;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.TestUtil;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+public class CertificateHandlerTest {
+
+    private Session session;
+    private SessionHandler sessionHandler;
+    private CertificateHandler certificateHandler;
+    private String certificateNotInDevice = "notInsideHSM";
+
+    @BeforeClass
+    public void setUpClass() throws CryptoException, ServerConfigurationException {
+
+        sessionHandler = TestUtil.getSessionHandler();
+    }
+
+    @BeforeMethod
+    public void setUp() throws CryptoException {
+
+        session = sessionHandler.initiateSession(0, null, false);
+        certificateHandler = new CertificateHandler(session);
+    }
+
+    @Test(dataProvider = "sampleCertificateRetrievalData")
+    public void testGetCertificate(Certificate certificateTemplate) {
+
+        try {
+            Certificate certificate = certificateHandler.getCertificate(certificateTemplate);
+            Assert.assertEquals(certificate.getLabel().getCharArrayValue(),
+                    certificateTemplate.getLabel().getCharArrayValue());
+        } catch (CryptoException e) {
+            if (certificateNotInDevice.equals(String.valueOf(certificateTemplate.getLabel().getCharArrayValue()))) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested certificate '%s' can't be found inside " +
+                        "the HSM.", String.valueOf(certificateTemplate.getLabel().getCharArrayValue())));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleCertificateRetrievalData")
+    public Object[][] getSampleCertificateData() {
+
+        Certificate certificateTemplate1 = new Certificate();
+        certificateTemplate1.getLabel().setCharArrayValue("wso2carbon".toCharArray());
+
+        Certificate certificateTemplate2 = new Certificate();
+        certificateTemplate2.getLabel().setCharArrayValue("5".toCharArray());
+
+        Certificate certificateTemplate3 = new Certificate();
+        certificateTemplate3.getLabel().setCharArrayValue("".toCharArray());
+
+        Certificate certificateTemplate4 = new Certificate();
+        certificateTemplate4.getLabel().setCharArrayValue(certificateNotInDevice.toCharArray());
+
+        return new Object[][]{
+                {
+                        certificateTemplate1
+                },
+                {
+                        certificateTemplate2
+                },
+                {
+                        certificateTemplate3
+                },
+                {
+                        certificateTemplate4
+                }
+        };
+    }
+
+    @AfterMethod
+    public void tearDown() throws CryptoException {
+
+        sessionHandler.closeSession(session);
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/KeyHandlerTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/objecthandlers/KeyHandlerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.AESSecretKey;
+import iaik.pkcs.pkcs11.objects.DES2SecretKey;
+import iaik.pkcs.pkcs11.objects.DES3SecretKey;
+import iaik.pkcs.pkcs11.objects.DESSecretKey;
+import iaik.pkcs.pkcs11.objects.Key;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+import iaik.pkcs.pkcs11.objects.SecretKey;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.TestUtil;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.exception.HSMCryptoException;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.KeyTemplateGenerator;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+public class KeyHandlerTest {
+
+    private SessionHandler sessionHandler;
+    private Session session;
+    private KeyHandler keyHandler;
+    private String keyAliasNotInHSM = "notInsideHSM";
+
+    @BeforeClass
+    public void setUpClass() throws CryptoException, ServerConfigurationException {
+
+        sessionHandler = TestUtil.getSessionHandler();
+    }
+
+    @BeforeMethod
+    public void setUp() throws CryptoException {
+
+        session = sessionHandler.initiateSession(0, null, true);
+        keyHandler = new KeyHandler(session);
+    }
+
+    @AfterMethod
+    public void tearDown() throws CryptoException {
+
+        sessionHandler.closeSession(session);
+    }
+
+    @Test(dataProvider = "sampleKeyRetrievalData")
+    public void testRetrieveKey(Key keyTemplate) {
+
+        try {
+            Key key = keyHandler.retrieveKey(keyTemplate);
+            Assert.assertEquals(String.valueOf(key.getLabel().getCharArrayValue()),
+                    String.valueOf(keyTemplate.getLabel().getCharArrayValue()));
+            Assert.assertTrue(key.getObjectHandle() != -1);
+        } catch (CryptoException e) {
+            if (keyAliasNotInHSM.equals(String.valueOf(keyTemplate.getLabel().getCharArrayValue()))) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested key with key alias %s can't be " +
+                        "found inside the HSM.", String.valueOf(keyTemplate.getLabel().getCharArrayValue())));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleKeyRetrievalData")
+    public Object[][] getSampleKeyData() {
+
+        ;
+
+        return new Object[][]{
+                {
+                        generateTemplate(new PrivateKey(), "wso2carbon")
+                },
+                {
+                        generateTemplate(new PublicKey(), "wso2carbon")
+                },
+                {
+                        generateTemplate(new SecretKey(), "sample")
+                },
+                {
+                        generateTemplate(new PublicKey(), keyAliasNotInHSM)
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleSecretKeyGeneratorDataProvider")
+    public void testGenerateSecretKey(SecretKey secretKeyTemplate, Mechanism keyGenerationMechanism) {
+
+        try {
+            SecretKey secretKey = keyHandler.generateSecretKey(secretKeyTemplate, keyGenerationMechanism);
+            Assert.assertTrue(secretKey.getObjectHandle() != -1);
+            Assert.assertNotNull(secretKey.getCheckValue().getByteArrayValue());
+        } catch (HSMCryptoException e) {
+            Assert.assertEquals(e.getMessage(), String.format("Error occurred while generating a %s secret key as a session object.",
+                    keyGenerationMechanism.getName()));
+        }
+    }
+
+    @DataProvider(name = "sampleSecretKeyGeneratorDataProvider")
+    public Object[][] getSampleSecretKeyData() {
+
+        AESSecretKey aesSecretKey = KeyTemplateGenerator.generateAESKeyTemplate();
+        aesSecretKey.getValueLen().setLongValue(16L);
+
+        DESSecretKey desSecretKey = KeyTemplateGenerator.generateDESKeyTemplate();
+
+        DES2SecretKey des2SecretKey = KeyTemplateGenerator.generateDES2KeyTemplate();
+
+        DES3SecretKey des3SecretKey = KeyTemplateGenerator.generateDES3KeyTemplate();
+
+        AESSecretKey aesSecretKey1 = KeyTemplateGenerator.generateAESKeyTemplate();
+        aesSecretKey1.getValueLen().setLongValue(16L);
+
+        return new Object[][]{
+                {
+                        aesSecretKey, Mechanism.get(PKCS11Constants.CKM_AES_KEY_GEN)
+                },
+                {
+                        desSecretKey, Mechanism.get(PKCS11Constants.CKM_DES_KEY_GEN)
+                },
+                {
+                        des2SecretKey, Mechanism.get(PKCS11Constants.CKM_DES2_KEY_GEN)
+                },
+                {
+                        des3SecretKey, Mechanism.get(PKCS11Constants.CKM_DES3_KEY_GEN)
+                },
+                {
+                        aesSecretKey1, Mechanism.get(PKCS11Constants.CKM_DES2_KEY_GEN)
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleSecretKeyHandleDataProvider")
+    public void testGetSecretKeyHandle(SecretKey secretKey) {
+
+        try {
+            SecretKey secretKeyWithHandle = (SecretKey) keyHandler.getKeyHandle(secretKey);
+            Assert.assertTrue(secretKeyWithHandle.getObjectHandle() != -1);
+            Assert.assertNotNull(secretKeyWithHandle.getCheckValue().getByteArrayValue());
+        } catch (HSMCryptoException e) {
+            Assert.assertEquals(e.getMessage(), String.format("Error occurred while generating an object handle for given %s " +
+                    "key.", String.valueOf(secretKey.getLabel().getCharArrayValue())));
+        }
+    }
+
+    @DataProvider(name = "sampleSecretKeyHandleDataProvider")
+    public Object[][] getSampleSecretKeyHandleData() {
+
+        AESSecretKey aesSecretKey = KeyTemplateGenerator.generateAESKeyTemplate();
+        aesSecretKey.getValue().setByteArrayValue(new byte[16]);
+
+        AESSecretKey aesSecretKey2 = KeyTemplateGenerator.generateAESKeyTemplate();
+        aesSecretKey2.getValue().setByteArrayValue(new byte[32]);
+
+        DES2SecretKey des2SecretKey = KeyTemplateGenerator.generateDES2KeyTemplate();
+        des2SecretKey.getValue().setByteArrayValue(new byte[16]);
+
+        DES3SecretKey des3SecretKey = KeyTemplateGenerator.generateDES3KeyTemplate();
+        des3SecretKey.getValue().setByteArrayValue(new byte[24]);
+
+        return new Object[][]{
+                {
+                        aesSecretKey
+                },
+                {
+                        aesSecretKey2
+                },
+                {
+                        des2SecretKey
+                },
+                {
+                        des3SecretKey
+                }
+        };
+    }
+
+    protected Key generateTemplate(Key keyTemplate, String keyAlias) {
+
+        keyTemplate.getLabel().setCharArrayValue(keyAlias.toCharArray());
+        return keyTemplate;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/CipherTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/CipherTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.AESSecretKey;
+import iaik.pkcs.pkcs11.objects.Key;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+import iaik.pkcs.pkcs11.objects.SecretKey;
+import iaik.pkcs.pkcs11.parameters.InitializationVectorParameters;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.TestUtil;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismDataHolder;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolver;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+import java.util.ArrayList;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.DECRYPT_MODE;
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.ENCRYPT_MODE;
+
+public class CipherTest {
+
+    private Cipher cipher;
+    private SessionHandler sessionHandler;
+    private Session session;
+    private MechanismResolver mechanismResolver;
+    private KeyHandler keyHandler;
+    private ArrayList<byte[]> sampleEncryptedData = new ArrayList<>();
+    private ArrayList<byte[]> sampleDataToBeEncrypted = new ArrayList<>();
+    private ArrayList<byte[]> ivs = new ArrayList<>();
+
+    @BeforeClass
+    public void setUpClass() throws CryptoException, ServerConfigurationException {
+
+        sessionHandler = TestUtil.getSessionHandler();
+        mechanismResolver = MechanismResolver.getInstance();
+    }
+
+    @BeforeMethod
+    public void setUp() throws CryptoException {
+
+        session = sessionHandler.initiateSession(0, null, false);
+        keyHandler = new KeyHandler(session);
+        cipher = new Cipher(session);
+    }
+
+    @AfterMethod
+    public void tearDown() throws CryptoException {
+
+        sessionHandler.closeSession(session);
+    }
+
+    @Test(dataProvider = "sampleEncryptionDataProvider")
+    public void testEncrypt(byte[] dataToBeEncrypted, Key encryptionKeyTemplate, Mechanism encryptionMechanism) {
+
+        try {
+            Key encryptionKey = keyHandler.retrieveKey(encryptionKeyTemplate);
+            byte[] encryptedData = cipher.encrypt(dataToBeEncrypted, encryptionKey, encryptionMechanism);
+            sampleEncryptedData.add(encryptedData);
+            if (encryptionMechanism.getParameters() instanceof InitializationVectorParameters) {
+                ivs.add(((InitializationVectorParameters) encryptionMechanism.getParameters()).getInitializationVector());
+            }
+        } catch (CryptoException e) {
+            if (!isEncryptDecryptMechanism(encryptionMechanism)) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested '%s' algorithm for data encryption is not a valid data " +
+                        "encryption mechanism.", encryptionMechanism.getName()));
+            }
+            sampleEncryptedData.add(dataToBeEncrypted);
+        }
+    }
+
+    @DataProvider(name = "sampleEncryptionDataProvider")
+    public Object[][] getSampleEncryptionData() throws CryptoException {
+
+        sampleDataToBeEncrypted.add("sample data for RSA OAEP".getBytes());
+        sampleDataToBeEncrypted.add("sample encryption for RSA".getBytes());
+        sampleDataToBeEncrypted.add("sample data set AES".getBytes());
+        sampleDataToBeEncrypted.add("sample encryption for DES".getBytes());
+
+        return new Object[][]{
+                {
+                        sampleDataToBeEncrypted.get(0), getKey(new PublicKey(), "wso2carbon"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(ENCRYPT_MODE, "RSA/ECB/OAEPwithMD5andMGF1Padding"))
+                },
+                {
+                        sampleDataToBeEncrypted.get(1), getKey(new PublicKey(), "wso2carbon"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(ENCRYPT_MODE, "RSA/ECB/PKCS1Padding"))
+                },
+                {
+                        sampleDataToBeEncrypted.get(2), getKey(new SecretKey(), "sample"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(ENCRYPT_MODE, "AES/CBC/PKCS5Padding"))
+                },
+                {
+                        sampleDataToBeEncrypted.get(3), getKey(new SecretKey(), "DES3 Secret Key"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(ENCRYPT_MODE, "3DES/CBC/PKCS5Padding"))
+                },
+                {
+                        sampleDataToBeEncrypted.get(0), getKey(new PrivateKey(), "wso2carbon"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(ENCRYPT_MODE, "AES/GCM/NoPadding", new byte[30]))
+                },
+                {
+                        sampleDataToBeEncrypted.get(0), getKey(new PrivateKey(), "wso2carbon"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(ENCRYPT_MODE, "SHA256withRSA", new byte[30]))
+                }
+        };
+    }
+
+    @Test(dataProvider = "sampleDecryptionDataProvider", priority = 1)
+    public void testDecrypt(byte[] dataToBeDecrypted, Key decryptionKeyTemplate, Mechanism decryptionMechanism,
+                            byte[] expectedDecryptedData) {
+
+        try {
+            Key decryptionKey = keyHandler.retrieveKey(decryptionKeyTemplate);
+            byte[] decryptedData = cipher.decrypt(dataToBeDecrypted, decryptionKey, decryptionMechanism);
+            Assert.assertEquals(decryptedData, expectedDecryptedData);
+        } catch (CryptoException e) {
+            if (!isEncryptDecryptMechanism(decryptionMechanism)) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested '%s' algorithm for data decryption is not a valid data " +
+                        "decryption mechanism.", decryptionMechanism.getName()));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleDecryptionDataProvider")
+    public Object[][] getSampleDecryptionData() throws CryptoException {
+
+        return new Object[][]{
+                {
+                        sampleEncryptedData.get(0), getKey(new PrivateKey(), "wso2carbon"),
+                        mechanismResolver.resolveMechanism(new MechanismDataHolder(DECRYPT_MODE,
+                                "RSA/ECB/OAEPwithMD5andMGF1Padding")), sampleDataToBeEncrypted.get(0)
+                },
+                {
+                        sampleEncryptedData.get(1), getKey(new PrivateKey(), "wso2carbon"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(DECRYPT_MODE,
+                        "RSA/ECB/PKCS1Padding")), sampleDataToBeEncrypted.get(1)
+                },
+                {
+                        sampleEncryptedData.get(2), getKey(new SecretKey(), "sample"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(DECRYPT_MODE, "AES/CBC/PKCS5Padding",
+                        new IvParameterSpec(ivs.get(0)))), sampleDataToBeEncrypted.get(2)
+                },
+                {
+                        sampleEncryptedData.get(3), getKey(new SecretKey(), "DES3 Secret Key"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(DECRYPT_MODE,
+                        "3DES/CBC/PKCS5Padding", new IvParameterSpec(ivs.get(1)))), sampleDataToBeEncrypted.get(3)
+                },
+                {
+                        sampleEncryptedData.get(4), getKey(new AESSecretKey(), "sample"), mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(DECRYPT_MODE, "AES/GCM/NoPadding",
+                        new GCMParameterSpec(96, new byte[16]), new byte[30])), sampleDataToBeEncrypted.get(0)
+                },
+                {
+                        sampleEncryptedData.get(4), getKey(new AESSecretKey(), "sample"), mechanismResolver.resolveMechanism(new
+                        MechanismDataHolder(DECRYPT_MODE, "SHA256withRSA",
+                        new GCMParameterSpec(96, new byte[16]), new byte[30])), sampleDataToBeEncrypted.get(0)
+                }
+        };
+    }
+
+    protected Key getKey(Key keyTemplate, String keyAlias) {
+
+        keyTemplate.getLabel().setCharArrayValue(keyAlias.toCharArray());
+        return keyTemplate;
+    }
+
+    protected boolean isEncryptDecryptMechanism(Mechanism mechanism) {
+
+        if (mechanism.isSingleOperationEncryptDecryptMechanism()
+                || mechanism.isFullEncryptDecryptMechanism()) {
+            return true;
+        }
+        if (mechanism.getMechanismCode() == PKCS11Constants.CKM_AES_GCM) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/SignatureHandlerTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/operators/SignatureHandlerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.objects.PrivateKey;
+import iaik.pkcs.pkcs11.objects.PublicKey;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.TestUtil;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismDataHolder;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolver;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+
+import java.util.ArrayList;
+
+import static org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.CryptoConstants.SIGN_MODE;
+
+public class SignatureHandlerTest {
+
+    private SessionHandler sessionHandler;
+    private SignatureHandler signatureHandler;
+    private Session session;
+    private MechanismResolver mechanismResolver;
+    private KeyHandler keyHandler;
+    private ArrayList<byte[]> signatures = new ArrayList<>();
+
+    @BeforeClass
+    public void setUpClass() throws CryptoException, ServerConfigurationException {
+
+        sessionHandler = TestUtil.getSessionHandler();
+        mechanismResolver = MechanismResolver.getInstance();
+    }
+
+    @BeforeMethod
+    public void setUp() throws CryptoException {
+
+        session = sessionHandler.initiateSession(0, null, false);
+        signatureHandler = new SignatureHandler(session);
+        keyHandler = new KeyHandler(session);
+    }
+
+    @AfterMethod
+    public void tearDown() throws CryptoException {
+
+        sessionHandler.closeSession(session);
+    }
+
+    @Test(dataProvider = "sampleSignDataProvider")
+    public void testSign(byte[] dataToSign,
+                         String signKeyAlias, Mechanism signMechanism) {
+
+        try {
+            PrivateKey signKey = getPrivateKey(signKeyAlias);
+            byte[] signature = signatureHandler.sign(dataToSign, signKey, signMechanism);
+            signatures.add(signature);
+        } catch (CryptoException e) {
+            if (!(signMechanism.isFullSignVerifyMechanism() || signMechanism.isSingleOperationSignVerifyMechanism())) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested '%s' algorithm for data signing is not a valid " +
+                        "signing mechanism.", signMechanism.getName()));
+            }
+        }
+    }
+
+    @Test(dataProvider = "sampleVerifyDataProvider", priority = 1)
+    public void testVerify(byte[] dataToVerify, String keyAlias,
+                           Mechanism verifyMechanism, byte[] signature, boolean expectedResult) {
+
+        try {
+            Assert.assertEquals(signatureHandler.verify(dataToVerify, signature, getPublicKey(keyAlias),
+                    verifyMechanism), expectedResult);
+        } catch (CryptoException e) {
+            if (!(verifyMechanism.isFullSignVerifyMechanism())) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested '%s' algorithm for signature verification is not a " +
+                        "valid sign verification mechanism.", verifyMechanism.getName()));
+            }
+        }
+    }
+
+    @DataProvider(name = "sampleSignDataProvider")
+    public Object[][] getSampleSignData() throws CryptoException {
+
+        return new Object[][]{
+                {
+                        "Sample Data to be signed".getBytes(), "wso2carbon",
+                        mechanismResolver.resolveMechanism(new MechanismDataHolder(SIGN_MODE, "SHA512withRSAandMGF1"))
+                },
+                {
+                        "".getBytes(), "wso2carbon", mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(SIGN_MODE, "SHA256withRSA"))
+                },
+                {
+                        "Sample signature".getBytes(), "wso2carbon", mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(SIGN_MODE, "SHA256withRSAandMGF1"))
+                },
+                {
+                        "Sample signature".getBytes(), "wso2carbon", mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(SIGN_MODE, "SHA1"))
+                },
+                {
+                        new byte[1000], "wso2carbon", Mechanism.get(PKCS11Constants.CKM_RSA_PKCS)
+                }
+        };
+    }
+
+    @DataProvider(name = "sampleVerifyDataProvider")
+    public Object[][] getSampleVerifyData() throws CryptoException {
+
+        return new Object[][]{
+                {
+                        "Sample Data to be signed".getBytes(), "wso2carbon",
+                        mechanismResolver.resolveMechanism(new MechanismDataHolder(SIGN_MODE,
+                                "SHA512withRSAandMGF1")), signatures.get(0), true
+                },
+                {
+                        "".getBytes(), "wso2carbon", mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(SIGN_MODE,
+                        "SHA256withRSA")), signatures.get(1), true
+                },
+                {
+                        "Sample signature".getBytes(), "wso2carbon", mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(SIGN_MODE,
+                        "SHA256withRSAandMGF1")), signatures.get(2), true
+                },
+                {
+                        "Sample signature".getBytes(), "wso2carbon",
+                        Mechanism.get(PKCS11Constants.CKM_RSA_PKCS), new byte[16], false
+                },
+                {
+                        "Sample signature2".getBytes(), "wso2carbon", mechanismResolver
+                        .resolveMechanism(new MechanismDataHolder(SIGN_MODE,
+                        "SHA256withRSAandMGF1")), signatures.get(2), false
+                }
+        };
+    }
+
+    protected PrivateKey getPrivateKey(String keyAlias) throws CryptoException {
+
+        PrivateKey privateKeyTemplate = new PrivateKey();
+        privateKeyTemplate.getLabel().setCharArrayValue(keyAlias.toCharArray());
+        privateKeyTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_PRIVATE_KEY);
+        return (PrivateKey) keyHandler.retrieveKey(privateKeyTemplate);
+    }
+
+    protected PublicKey getPublicKey(String keyAlias) throws CryptoException {
+
+        PublicKey publicKeyTemplate = new PublicKey();
+        publicKeyTemplate.getLabel().setCharArrayValue(keyAlias.toCharArray());
+        publicKeyTemplate.getObjectClass().setLongValue(PKCS11Constants.CKO_PUBLIC_KEY);
+        return (PublicKey) keyHandler.retrieveKey(publicKeyTemplate);
+
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/KeyTemplateGeneratorTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/KeyTemplateGeneratorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import iaik.pkcs.pkcs11.objects.AESSecretKey;
+import iaik.pkcs.pkcs11.objects.DES2SecretKey;
+import iaik.pkcs.pkcs11.objects.DES3SecretKey;
+import iaik.pkcs.pkcs11.objects.DESSecretKey;
+import iaik.pkcs.pkcs11.objects.SecretKey;
+import iaik.pkcs.pkcs11.wrapper.PKCS11Constants;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class KeyTemplateGeneratorTest {
+
+    @Test
+    public void testGenerateAESKeyTemplate() {
+
+        AESSecretKey secretKey = KeyTemplateGenerator.generateAESKeyTemplate();
+        Assert.assertEquals((long) secretKey.getKeyType().getLongValue(), PKCS11Constants.CKK_AES);
+        testCommonFeatures(secretKey);
+    }
+
+    @Test
+    public void testGenerateDESKeyTemplate() {
+
+        DESSecretKey secretKey = KeyTemplateGenerator.generateDESKeyTemplate();
+        Assert.assertEquals((long) secretKey.getKeyType().getLongValue(), PKCS11Constants.CKK_DES);
+        testCommonFeatures(secretKey);
+    }
+
+    @Test
+    public void testGenerateDES2KeyTemplate() {
+
+        DES2SecretKey secretKey = KeyTemplateGenerator.generateDES2KeyTemplate();
+        Assert.assertEquals((long) secretKey.getKeyType().getLongValue(), PKCS11Constants.CKK_DES2);
+        testCommonFeatures(secretKey);
+    }
+
+    @Test
+    public void testGenerateDES3KeyTemplate() {
+
+        DES3SecretKey secretKey = KeyTemplateGenerator.generateDES3KeyTemplate();
+        Assert.assertEquals((long) secretKey.getKeyType().getLongValue(), PKCS11Constants.CKK_DES3);
+        testCommonFeatures(secretKey);
+    }
+
+    private void testCommonFeatures(SecretKey secretKey) {
+
+        Assert.assertEquals((long) secretKey.getObjectClass().getLongValue(), PKCS11Constants.CKO_SECRET_KEY);
+        Assert.assertTrue(secretKey.getExtractable().getBooleanValue());
+        Assert.assertFalse(secretKey.getSensitive().getBooleanValue());
+        Assert.assertFalse(secretKey.getToken().getBooleanValue());
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismResolverTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/MechanismResolverTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import iaik.pkcs.pkcs11.Mechanism;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.crypto.api.CryptoException;
+
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+public class MechanismResolverTest {
+
+    private MechanismResolver mechanismResolver;
+
+    @BeforeClass
+    public void setUpClass() {
+
+        this.mechanismResolver = MechanismResolver.getInstance();
+    }
+
+    @Test
+    public void testGetSupportedMechanisms() {
+
+        Assert.assertNotNull(MechanismResolver.getSupportedMechanisms());
+    }
+
+    @Test(dataProvider = "mechanismDataProvider")
+    public void testResolveMechanism(MechanismDataHolder mechanismDataHolder) {
+
+        try {
+            Mechanism mechanism = mechanismResolver.resolveMechanism(mechanismDataHolder);
+            Assert.assertEquals(mechanism.getMechanismCode(), (long) MechanismResolver.getSupportedMechanisms()
+                    .get(mechanismDataHolder.getJceMechanismSpecification()));
+        } catch (CryptoException e) {
+            if (!MechanismResolver.getSupportedMechanisms().containsKey(mechanismDataHolder.getJceMechanismSpecification())) {
+                Assert.assertEquals(e.getMessage(), String.format("Requested %s algorithm is not supported by " +
+                        "HSM based crypto provider.", mechanismDataHolder.getJceMechanismSpecification()));
+            }
+        }
+    }
+
+    @DataProvider(name = "mechanismDataProvider")
+    public Object[][] getMechanismData() {
+
+        MechanismDataHolder mechanismDataHolder1 = new MechanismDataHolder(CryptoConstants.VERIFY_MODE,
+                "SHA256withRSAandMGF1");
+        MechanismDataHolder mechanismDataHolder2 = new MechanismDataHolder(CryptoConstants.SIGN_MODE,
+                "SHA256withRSAandMGF1");
+
+        MechanismDataHolder mechanismDataHolder3 = new MechanismDataHolder(CryptoConstants.ENCRYPT_MODE,
+                "DES/CBC/PKCS5Padding");
+        MechanismDataHolder mechanismDataHolder4 = new MechanismDataHolder(CryptoConstants.DECRYPT_MODE,
+                "DES/CBC/PKCS5Padding", new IvParameterSpec(new byte[8]));
+
+        MechanismDataHolder mechanismDataHolder5 = new MechanismDataHolder(CryptoConstants.ENCRYPT_MODE,
+                "AES/CBC/PKCS5Padding");
+        MechanismDataHolder mechanismDataHolder6 = new MechanismDataHolder(CryptoConstants.DECRYPT_MODE,
+                "AES/CBC/PKCS5Padding", new IvParameterSpec(new byte[16]));
+
+        MechanismDataHolder mechanismDataHolder7 = new MechanismDataHolder(CryptoConstants.ENCRYPT_MODE,
+                "AES/GCM/NoPadding", new byte[16]);
+        MechanismDataHolder mechanismDataHolder8 = new MechanismDataHolder(CryptoConstants.DECRYPT_MODE,
+                "AES/GCM/NoPadding", new GCMParameterSpec(128, new byte[12]), new byte[16]);
+
+        MechanismDataHolder mechanismDataHolder9 = new MechanismDataHolder(CryptoConstants.ENCRYPT_MODE,
+                "RSA/ECB/OAEPwithSHA224andMGF1Padding");
+        MechanismDataHolder mechanismDataHolder10 = new MechanismDataHolder(CryptoConstants.DECRYPT_MODE,
+                "RSA/ECB/OAEPwithSHA224andMGF1Padding");
+
+        MechanismDataHolder mechanismDataHolder11 = new MechanismDataHolder(CryptoConstants.ENCRYPT_MODE, "asdsadsa");
+
+        return new Object[][]{
+                {
+                        mechanismDataHolder1
+                },
+                {
+                        mechanismDataHolder2
+                },
+                {
+                        mechanismDataHolder3
+                },
+                {
+                        mechanismDataHolder4
+                },
+                {
+                        mechanismDataHolder5
+                },
+                {
+                        mechanismDataHolder6
+                },
+                {
+                        mechanismDataHolder7
+                },
+                {
+                        mechanismDataHolder8
+                },
+                {
+                        mechanismDataHolder9
+                },
+                {
+                        mechanismDataHolder10
+                },
+                {
+                        mechanismDataHolder11
+                }
+        };
+    }
+
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/SessionHandlerTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/SessionHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util;
+
+import iaik.pkcs.pkcs11.Session;
+import iaik.pkcs.pkcs11.TokenException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.ServerConfigurationException;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.TestUtil;
+
+public class SessionHandlerTest {
+
+    private ServerConfigurationService serverConfigurationService;
+    private SessionHandler sessionHandler;
+
+    @BeforeClass
+    public void setUpClass() throws ServerConfigurationException, CryptoException {
+
+        serverConfigurationService = TestUtil.getServerConfigurationService();
+        sessionHandler = SessionHandler.getDefaultSessionHandler(serverConfigurationService);
+    }
+
+    @Test(dataProvider = "initiateSessionDataProvider")
+    public void testInitiateSession(int slotNo, boolean readWrite) throws TokenException {
+
+        try {
+            Session session = sessionHandler.initiateSession(slotNo, null, readWrite);
+            Assert.assertTrue((session.getSessionInfo().isRwSession() == readWrite));
+            //Close the created session.
+            sessionHandler.closeSession(session);
+        } catch (CryptoException e) {
+
+        }
+    }
+
+    @DataProvider(name = "initiateSessionDataProvider")
+    public Object[][] createSessionInitiationData() {
+
+        return new Object[][]{
+                {
+                        0, true
+                },
+                {
+                        0, false
+                },
+                {
+                        1, true
+                },
+                {
+                        100, false
+                }
+        };
+    }
+}

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/SessionHandlerTest.java
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/org/wso2/carbon/crypto/provider/hsm/cryptoprovider/util/SessionHandlerTest.java
@@ -47,7 +47,7 @@ public class SessionHandlerTest {
         try {
             Session session = sessionHandler.initiateSession(slotNo, null, readWrite);
             Assert.assertTrue((session.getSessionInfo().isRwSession() == readWrite));
-            //Close the created session.
+            // Close the created session.
             sessionHandler.closeSession(session);
         } catch (CryptoException e) {
 

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/resources/home/repository/conf/carbon.xml
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/resources/home/repository/conf/carbon.xml
@@ -1,0 +1,752 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!--
+    This is the main server configuration file
+
+    ${carbon.home} represents the carbon.home system property.
+    Other system properties can be specified in a similar manner.
+-->
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <!--
+       Product Name
+    -->
+    <Name>WSO2 Identity Server</Name>
+
+    <!--
+       machine readable unique key to identify each product
+    -->
+    <ServerKey>IS</ServerKey>
+
+    <!--
+       Product Version
+    -->
+    <Version>5.7.0-SNAPSHOT</Version>
+
+    <!--
+       Host name or IP address of the machine hosting this server
+       e.g. www.wso2.org, 192.168.1.10
+       This is will become part of the End Point Reference of the
+       services deployed on this server instance.
+    -->
+    <HostName>localhost</HostName>
+
+    <!--
+    Host name to be used for the Carbon management console
+    -->
+    <MgtHostName>localhost</MgtHostName>
+
+    <!--
+        The URL of the back end server. This is where the admin services are hosted and
+        will be used by the clients in the front end server.
+        This is required only for the Front-end server. This is used when seperating BE server from FE server
+       -->
+    <ServerURL>local:/${carbon.context}/services/</ServerURL>
+    <!--
+    <ServerURL>https://localhost:${carbon.management.port}${carbon.context}/services/</ServerURL>
+    -->
+    <!--
+    The URL of the index page. This is where the user will be redirected after signing in to the
+    carbon server.
+    -->
+    <!-- IndexPageURL>/carbon/admin/index.jsp</IndexPageURL-->
+
+    <!--
+    For cApp deployment, we have to identify the roles that can be acted by the current server.
+    The following property is used for that purpose. Any number of roles can be defined here.
+    Regular expressions can be used in the role.
+    Ex : <Role>.*</Role> means this server can act any role
+    -->
+    <ServerRoles>
+        <Role>IdentityServer</Role>
+    </ServerRoles>
+
+    <!-- uncommnet this line to subscribe to a bam instance automatically -->
+    <!--<BamServerURL>https://bamhost:bamport/services/</BamServerURL>-->
+
+    <!--
+       The fully qualified name of the server
+    -->
+    <Package>org.wso2.carbon</Package>
+
+    <!--
+       Webapp context root of WSO2 Carbon management console.
+    -->
+    <WebContextRoot>/</WebContextRoot>
+
+    <!--
+    	Proxy context path is a useful parameter to add a proxy path when a Carbon server is fronted by reverse proxy. In addtion
+        to the proxy host and proxy port this parameter allows you add a path component to external URLs. e.g.
+     		URL of the Carbon server -> https://10.100.1.1:9443/carbon
+   		URL of the reverse proxy -> https://prod.abc.com/appserver/carbon
+
+   	appserver - proxy context path. This specially required whenever you are generating URLs to displace in
+   	Carbon UI components.
+    -->
+    <!--
+    	<MgtProxyContextPath></MgtProxyContextPath>
+    	<ProxyContextPath></ProxyContextPath>
+    -->
+
+    <!-- In-order to  get the registry http Port from the back-end when the default http transport is not the same-->
+    <!--RegistryHttpPort>9763</RegistryHttpPort-->
+
+    <!--
+    Number of items to be displayed on a management console page. This is used at the
+    backend server for pagination of various items.
+    -->
+    <ItemsPerPage>15</ItemsPerPage>
+
+    <!-- The endpoint URL of the cloud instance management Web service -->
+    <!--<InstanceMgtWSEndpoint>https://ec2.amazonaws.com/</InstanceMgtWSEndpoint>-->
+
+    <!--
+       Ports used by this server
+    -->
+    <Ports>
+
+        <!-- Ports offset. This entry will set the value of the ports defined below to
+         the define value + Offset.
+         e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
+         -->
+        <Offset>0</Offset>
+
+        <!-- The JMX Ports -->
+        <JMX>
+            <!--The port RMI registry is exposed-->
+            <RMIRegistryPort>9999</RMIRegistryPort>
+            <!--The port RMI server should be exposed-->
+            <RMIServerPort>11111</RMIServerPort>
+        </JMX>
+
+        <!-- Embedded LDAP server specific ports -->
+        <EmbeddedLDAP>
+            <!-- Port which embedded LDAP server runs -->
+            <LDAPServerPort>10389</LDAPServerPort>
+            <!-- Port which KDC (Kerberos Key Distribution Center) server runs -->
+            <KDCServerPort>8000</KDCServerPort>
+        </EmbeddedLDAP>
+
+        <!--
+                 Override datasources JNDIproviderPort defined in bps.xml and datasources.properties files
+        -->
+        <!--<JNDIProviderPort>2199</JNDIProviderPort>-->
+        <!--Override receive port of thrift based entitlement service.-->
+        <ThriftEntitlementReceivePort>10500</ThriftEntitlementReceivePort>
+
+        <!--
+         This is the proxy port of the worker cluster. These need to be configured in a scenario where
+         manager node is not exposed through the load balancer through which the workers are exposed
+         therefore doesn't have a proxy port.
+        <WorkerHttpProxyPort>80</WorkerHttpProxyPort>
+        <WorkerHttpsProxyPort>443</WorkerHttpsProxyPort>
+        -->
+
+    </Ports>
+
+    <!--
+        JNDI Configuration
+    -->
+    <JNDI>
+        <!-- 
+             The fully qualified name of the default initial context factory
+        -->
+        <DefaultInitialContextFactory>org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory
+        </DefaultInitialContextFactory>
+        <!-- 
+             The restrictions that are done to various JNDI Contexts in a Multi-tenant environment 
+        -->
+        <Restrictions>
+            <!--
+                Contexts that will be available only to the super-tenant
+            -->
+            <!-- <SuperTenantOnly>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext>
+                    <UrlContext>
+                        <Scheme>bar</Scheme>
+                    </UrlContext>
+                </UrlContexts>
+            </SuperTenantOnly> -->
+            <!-- 
+                Contexts that are common to all tenants
+            -->
+            <AllTenants>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>java</Scheme>
+                    </UrlContext>
+                    <!-- <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext> -->
+                </UrlContexts>
+            </AllTenants>
+            <!-- 
+                 All other contexts not mentioned above will be available on a per-tenant basis 
+                 (i.e. will not be shared among tenants)
+            -->
+        </Restrictions>
+    </JNDI>
+
+    <!--
+        Property to determine if the server is running an a cloud deployment environment.
+        This property should only be used to determine deployment specific details that are
+        applicable only in a cloud deployment, i.e when the server deployed *-as-a-service.
+    -->
+    <IsCloudDeployment>false</IsCloudDeployment>
+
+    <!--
+	Property to determine whether usage data should be collected for metering purposes
+    -->
+    <EnableMetering>false</EnableMetering>
+
+    <!-- The Max time a thread should take for execution in seconds -->
+    <MaxThreadExecutionTime>600</MaxThreadExecutionTime>
+
+    <!--
+        A flag to enable or disable Ghost Deployer. By default this is set to false. That is
+        because the Ghost Deployer works only with the HTTP/S transports. If you are using
+        other transports, don't enable Ghost Deployer.
+    -->
+    <GhostDeployment>
+        <Enabled>false</Enabled>
+    </GhostDeployment>
+
+
+    <!--
+        Eager loading or lazy loading is a design pattern commonly used in computer programming which
+        will initialize an object upon creation or load on-demand. In carbon, lazy loading is used to
+        load tenant when a request is received only. Similarly Eager loading is used to enable load
+        existing tenants after carbon server starts up. Using this feature, you will be able to include
+        or exclude tenants which are to be loaded when server startup.
+
+        We can enable only one LoadingPolicy at a given time.
+
+        1. Tenant Lazy Loading
+           This is the default behaviour and enabled by default. With this policy, tenants are not loaded at
+           server startup, but loaded based on-demand (i.e when a request is received for a tenant).
+           The default tenant idle time is 30 minutes.
+
+        2. Tenant Eager Loading
+           This is by default not enabled. It can be be enabled by un-commenting the <EagerLoading> section.
+           The eager loading configurations supported are as below. These configurations can be given as the
+           value for <Include> element with eager loading.
+                (i)Load all tenants when server startup             -   *
+                (ii)Load all tenants except foo.com & bar.com       -   *,!foo.com,!bar.com
+                (iii)Load only foo.com &  bar.com to be included    -   foo.com,bar.com
+    -->
+    <Tenant>
+        <LoadingPolicy>
+            <LazyLoading>
+                <IdleTime>30</IdleTime>
+            </LazyLoading>
+            <!-- <EagerLoading>
+                   <Include>*,!foo.com,!bar.com</Include>
+            </EagerLoading>-->
+        </LoadingPolicy>
+    </Tenant>
+
+    <!--
+     Caching related configurations
+    -->
+    <Cache>
+        <!-- Default cache timeout in minutes -->
+        <DefaultCacheTimeout>15</DefaultCacheTimeout>
+        <!-- Force all caches to act as local -->
+        <ForceLocalCache>false</ForceLocalCache>
+    </Cache>
+
+    <!--
+    Axis2 related configurations
+    -->
+    <Axis2Config>
+        <!--
+             Location of the Axis2 Services & Modules repository
+
+             This can be a directory in the local file system, or a URL.
+
+             e.g.
+             1. /home/wso2wsas/repository/ - An absolute path
+             2. repository - In this case, the path is relative to CARBON_HOME
+             3. file:///home/wso2wsas/repository/
+             4. http://wso2wsas/repository/
+        -->
+        <RepositoryLocation>${carbon.home}/repository/deployment/server/</RepositoryLocation>
+
+        <!--
+         Deployment update interval in seconds. This is the interval between repository listener
+         executions. 
+        -->
+        <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
+
+        <!--
+            Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
+
+            This can be a file on the local file system, or a URL
+
+            e.g.
+            1. /home/repository/axis2.xml - An absolute path
+            2. conf/axis2.xml - In this case, the path is relative to CARBON_HOME
+            3. file:///home/carbon/repository/axis2.xml
+            4. http://repository/conf/axis2.xml
+        -->
+        <ConfigurationFile>${carbon.home}/repository/conf/axis2/axis2.xml</ConfigurationFile>
+
+        <!--
+          ServiceGroupContextIdleTime, which will be set in ConfigurationContex
+          for multiple clients which are going to access the same ServiceGroupContext
+          Default Value is 30 Sec.
+        -->
+        <ServiceGroupContextIdleTime>30000</ServiceGroupContextIdleTime>
+
+        <!--
+          This repository location is used to crete the client side configuration
+          context used by the server when calling admin services.
+        -->
+        <ClientRepositoryLocation>${carbon.home}/repository/deployment/client/</ClientRepositoryLocation>
+        <!-- This axis2 xml is used in createing the configuration context by the FE server
+         calling to BE server -->
+        <clientAxis2XmlLocation>${carbon.home}/repository/conf/axis2/axis2_client.xml</clientAxis2XmlLocation>
+        <!-- If this parameter is set, the ?wsdl on an admin service will not give the admin service wsdl. -->
+        <HideAdminServiceWSDLs>true</HideAdminServiceWSDLs>
+
+        <!--WARNING-Use With Care! Uncommenting bellow parameter would expose all AdminServices in HTTP transport.
+        With HTTP transport your credentials and data routed in public channels are vulnerable for sniffing attacks.
+        Use bellow parameter ONLY if your communication channels are confirmed to be secured by other means -->
+        <!--HttpAdminServices>*</HttpAdminServices-->
+
+    </Axis2Config>
+
+    <!--
+       The default user roles which will be created when the server
+       is started up for the first time.
+    -->
+    <ServiceUserRoles>
+        <Role>
+            <Name>admin</Name>
+            <Description>Default Administrator Role</Description>
+        </Role>
+        <Role>
+            <Name>user</Name>
+            <Description>Default User Role</Description>
+        </Role>
+    </ServiceUserRoles>
+
+    <!--
+       Configurations related to Carbon Crypto Service which is a crypto framework used inside Carbon products.
+    -->
+    <CryptoService>
+
+        <Enabled>true</Enabled>
+
+        <!-- The crypto provider which is used for internal data encryption and decryption -->
+
+        <InternalCryptoProviderClassName>org.wso2.carbon.crypto.provider.hsm.HSMBasedInternalCryptoProvider
+        </InternalCryptoProviderClassName>
+        <!--
+        <InternalCryptoProviderClassName>org.wso2.carbon.crypto.provider.KeyStoreBasedInternalCryptoProvider</InternalCryptoProviderClassName>
+              -->
+        The crypto provider which is used for the crypto needs which come when communicating with external parties.
+        e.g. Signing, Decrypting.
+        <!--
+        <ExternalCryptoProviderClassName>org.wso2.carbon.core.encryption.KeyStoreBasedExternalCryptoProvider</ExternalCryptoProviderClassName>
+	-->
+
+        <ExternalCryptoProviderClassName>org.wso2.carbon.crypto.provider.hsm.HSMBasedExternalCryptoProvider
+        </ExternalCryptoProviderClassName>
+
+        <!--
+            The list of key resolvers which will be used based on the context when handling crypto with external parties.
+
+            e.g. Resolving the public key of an external entity.
+        -->
+        <KeyResolvers>
+            <KeyResolver className="org.wso2.carbon.crypto.defaultProvider.resolver.ContextIndependentKeyResolver"
+                         priority="99"/>
+            <KeyResolver className="org.wso2.carbon.identity.cryptoutil.OAuthServiceProviderKeyResolver" priority="2"/>
+            <KeyResolver className="org.wso2.carbon.crypto.provider.hsm.HSMBasedKeyResolver" priority="100"/>
+        </KeyResolvers>
+
+        <HSMBasedCryptoProviderConfig>
+            <HSMConfiguration>
+                <PKCS11Module>/etc/utimaco/libcs_pkcs11_R2.so</PKCS11Module>
+                <SlotConfiguration>
+                    <Slot id="0" pin="12345"/>
+                </SlotConfiguration>
+            </HSMConfiguration>
+
+            <InternalProvider>
+                <InternalProviderSlotID>0</InternalProviderSlotID>
+                <CertificateAlias>carbon.super</CertificateAlias>
+                <KeyAlias>wso2carbon</KeyAlias>
+            </InternalProvider>
+
+            <ExternalProvider>
+                <ExternalProviderSlotID>0</ExternalProviderSlotID>
+            </ExternalProvider>
+        </HSMBasedCryptoProviderConfig>
+
+    </CryptoService>
+
+    <!-- 
+      Enable following config to allow Emails as usernames. 	
+    -->
+    <!--EnableEmailUserName>true</EnableEmailUserName-->
+
+    <!--
+      Security configurations
+    -->
+    <Security>
+        <!--
+            KeyStore which will be used for encrypting/decrypting passwords
+            and other sensitive information.
+        -->
+        <KeyStore>
+            <!-- Keystore file location-->
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>JKS</Type>
+            <!-- Keystore password-->
+            <Password>wso2carbon</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>wso2carbon</KeyAlias>
+            <!-- Private Key password-->
+            <KeyPassword>wso2carbon</KeyPassword>
+        </KeyStore>
+
+        <!--
+            The KeyStore which is used for encrypting/decrypting internal data.
+            This block is read by Carbon Crypto Service.
+        -->
+        <InternalKeyStore>
+            <!-- Keystore file location-->
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>JKS</Type>
+            <!-- Keystore password-->
+            <Password>wso2carbon</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>wso2carbon</KeyAlias>
+            <!-- Private Key password-->
+            <KeyPassword>wso2carbon</KeyPassword>
+        </InternalKeyStore>
+
+        <!--
+            System wide trust-store which is used to maintain the certificates of all
+            the trusted parties.
+        -->
+        <TrustStore>
+            <!-- trust-store file location -->
+            <Location>${carbon.home}/repository/resources/security/client-truststore.jks</Location>
+            <!-- trust-store type (JKS/PKCS12 etc.) -->
+            <Type>JKS</Type>
+            <!-- trust-store password -->
+            <Password>wso2carbon</Password>
+        </TrustStore>
+
+        <!--
+            The Authenticator configuration to be used at the JVM level. We extend the
+            java.net.Authenticator to make it possible to authenticate to given servers and 
+            proxies.
+        -->
+        <NetworkAuthenticatorConfig>
+            <!-- 
+                Below is a sample configuration for a single authenticator. Please note that
+                all child elements are mandatory. Not having some child elements would lead to
+                exceptions at runtime.
+            -->
+            <!-- <Credential> -->
+            <!--
+                the pattern that would match a subset of URLs for which this authenticator
+                would be used
+            -->
+            <!-- <Pattern>regularExpression</Pattern> -->
+            <!--
+                the type of this authenticator. Allowed values are:
+                1. server
+                2. proxy
+            -->
+            <!-- <Type>proxy</Type> -->
+            <!-- the username used to log in to server/proxy -->
+            <!-- <Username>username</Username> -->
+            <!-- the password used to log in to server/proxy -->
+            <!-- <Password>password</Password> -->
+            <!-- </Credential> -->
+        </NetworkAuthenticatorConfig>
+
+        <!--
+         The Tomcat realm to be used for hosted Web applications. Allowed values are;
+         1. UserManager
+         2. Memory
+
+         If this is set to 'UserManager', the realm will pick users & roles from the system's
+         WSO2 User Manager. If it is set to 'memory', the realm will pick users & roles from
+         CARBON_HOME/repository/conf/tomcat/tomcat-users.xml
+        -->
+        <TomcatRealm>UserManager</TomcatRealm>
+
+        <!--Option to disable storing of tokens issued by STS-->
+        <DisableTokenStore>false</DisableTokenStore>
+
+        <STSCallBackHandlerName>org.wso2.carbon.identity.provider.AttributeCallbackHandler</STSCallBackHandlerName>
+
+        <!--
+         Security token store class name. If this is not set, default class will be
+         org.wso2.carbon.security.util.SecurityTokenStore
+        -->
+        <TokenStoreClassName>org.wso2.carbon.identity.sts.store.DBTokenStore</TokenStoreClassName>
+
+        <XSSPreventionConfig>
+            <Enabled>true</Enabled>
+            <Rule>allow</Rule>
+            <Patterns>
+                <!--Pattern></Pattern-->
+            </Patterns>
+        </XSSPreventionConfig>
+    </Security>
+    <HideMenuItemIds>
+        <HideMenuItemId>claim_mgt_menu</HideMenuItemId>
+        <HideMenuItemId>identity_mgt_emailtemplate_menu</HideMenuItemId>
+        <HideMenuItemId>identity_security_questions_menu</HideMenuItemId>
+    </HideMenuItemIds>
+
+    <!--
+       The temporary work directory
+    -->
+    <WorkDirectory>${carbon.home}/tmp/work</WorkDirectory>
+
+    <!--
+       House-keeping configuration
+    -->
+    <HouseKeeping>
+
+        <!--
+           true  - Start House-keeping thread on server startup
+           false - Do not start House-keeping thread on server startup.
+                   The user will run it manually as and when he wishes.
+        -->
+        <AutoStart>true</AutoStart>
+
+        <!--
+           The interval in *minutes*, between house-keeping runs
+        -->
+        <Interval>10</Interval>
+
+        <!--
+          The maximum time in *minutes*, temp files are allowed to live
+          in the system. Files/directories which were modified more than
+          "MaxTempFileLifetime" minutes ago will be removed by the
+          house-keeping task
+        -->
+        <MaxTempFileLifetime>30</MaxTempFileLifetime>
+    </HouseKeeping>
+
+    <!--
+       Configuration for handling different types of file upload & other file uploading related
+       config parameters.
+       To map all actions to a particular FileUploadExecutor, use
+       <Action>*</Action>
+    -->
+    <FileUploadConfig>
+        <!--
+           The total file upload size limit in MB
+        -->
+        <TotalFileSizeLimit>100</TotalFileSizeLimit>
+
+        <Mapping>
+            <Actions>
+                <Action>keystore</Action>
+                <Action>certificate</Action>
+                <Action>*</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.AnyFileUploadExecutor</Class>
+        </Mapping>
+
+        <Mapping>
+            <Actions>
+                <Action>jarZip</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.JarZipUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>dbs</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.DBSFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>tools</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>toolsAny</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsAnyFileUploadExecutor</Class>
+        </Mapping>
+    </FileUploadConfig>
+
+    <!-- FileNameRegEx is used to validate the file input/upload/write-out names.
+    e.g.
+     <FileNameRegEx>^(?!(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.[^.])?$)[^&lt;&gt:"/\\|?*\x00-\x1F][^&lt;&gt:"/\\|?*\x00-\x1F\ .]$</FileNameRegEx>
+    -->
+    <!--<FileNameRegEx></FileNameRegEx>-->
+
+    <!--
+       Processors which process special HTTP GET requests such as ?wsdl, ?policy etc.
+
+       In order to plug in a processor to handle a special request, simply add an entry to this
+       section.
+
+       The value of the Item element is the first parameter in the query string(e.g. ?wsdl)
+       which needs special processing
+       
+       The value of the Class element is a class which implements
+       org.wso2.carbon.transport.HttpGetRequestProcessor
+    -->
+    <HttpGetRequestProcessors>
+        <Processor>
+            <Item>info</Item>
+            <Class>org.wso2.carbon.core.transports.util.InfoProcessor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl11Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl2</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl20Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>xsd</Item>
+            <Class>org.wso2.carbon.core.transports.util.XsdProcessor</Class>
+        </Processor>
+    </HttpGetRequestProcessors>
+
+    <!-- Deployment Synchronizer Configuration. Enable value to true when running with "svn based" dep sync.
+	In master nodes you need to set both AutoCommit and AutoCheckout to true
+	and in  worker nodes set only AutoCheckout to true.
+    -->
+    <DeploymentSynchronizer>
+        <Enabled>false</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+        <RepositoryType>svn</RepositoryType>
+        <SvnUrl>http://svnrepo.example.com/repos/</SvnUrl>
+        <SvnUser>username</SvnUser>
+        <SvnPassword>password</SvnPassword>
+        <SvnUrlAppendTenantId>true</SvnUrlAppendTenantId>
+    </DeploymentSynchronizer>
+
+    <!-- Mediation persistence configurations. Only valid if mediation features are available i.e. ESB -->
+    <!--<MediationConfig>
+        <LoadFromRegistry>false</LoadFromRegistry>
+        <SaveToFile>false</SaveToFile>
+        <Persistence>enabled</Persistence>
+        <RegistryPersistence>enabled</RegistryPersistence>
+    </MediationConfig>-->
+
+    <!--
+    Server intializing code, specified as implementation classes of org.wso2.carbon.core.ServerInitializer.
+    This code will be run when the Carbon server is initialized
+    -->
+    <ServerInitializers>
+        <!--<Initializer></Initializer>-->
+    </ServerInitializers>
+
+    <!--
+    Indicates whether the Carbon Servlet is required by the system, and whether it should be
+    registered
+    -->
+    <RequireCarbonServlet>${require.carbon.servlet}</RequireCarbonServlet>
+
+    <!--
+    Carbon H2 OSGI Configuration
+    By default non of the servers start.
+        name="web" - Start the web server with the H2 Console
+        name="webPort" - The port (default: 8082)
+        name="webAllowOthers" - Allow other computers to connect
+        name="webSSL" - Use encrypted (HTTPS) connections
+        name="tcp" - Start the TCP server
+        name="tcpPort" - The port (default: 9092)
+        name="tcpAllowOthers" - Allow other computers to connect
+        name="tcpSSL" - Use encrypted (SSL) connections
+        name="pg" - Start the PG server
+        name="pgPort"  - The port (default: 5435)
+        name="pgAllowOthers"  - Allow other computers to connect
+        name="trace" - Print additional trace information; for all servers
+        name="baseDir" - The base directory for H2 databases; for all servers  
+    -->
+    <!--H2DatabaseConfiguration>
+        <property name="web" />
+        <property name="webPort">8082</property>
+        <property name="webAllowOthers" />
+        <property name="webSSL" />
+        <property name="tcp" />
+        <property name="tcpPort">9092</property>
+        <property name="tcpAllowOthers" />
+        <property name="tcpSSL" />
+        <property name="pg" />
+        <property name="pgPort">5435</property>
+        <property name="pgAllowOthers" />
+        <property name="trace" />
+        <property name="baseDir">${carbon.home}</property>
+    </H2DatabaseConfiguration-->
+    <!--Disabling statistics reporter by default-->
+    <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
+
+    <!-- Enable accessing Admin Console via HTTP -->
+    <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
+
+    <!--
+       Default Feature Repository of WSO2 Carbon.
+    -->
+    <FeatureRepository>
+        <RepositoryName>default repository</RepositoryName>
+        <RepositoryURL>http://product-dist.wso2.com/p2/carbon/releases/wilkes/</RepositoryURL>
+    </FeatureRepository>
+
+    <!--
+	Configure API Management
+   -->
+    <APIManagement>
+
+        <!--Uses the embedded API Manager by default. If you want to use an external
+        API Manager instance to manage APIs, configure below  externalAPIManager-->
+
+        <Enabled>true</Enabled>
+
+        <!--Uncomment and configure API Gateway and
+        Publisher URLs to use external API Manager instance-->
+
+        <!--ExternalAPIManager>
+
+            <APIGatewayURL>http://localhost:8281</APIGatewayURL>
+            <APIPublisherURL>http://localhost:8281/publisher</APIPublisherURL>
+
+        </ExternalAPIManager-->
+
+        <LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
+    </APIManagement>
+</Server>

--- a/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/resources/testng.xml
+++ b/components/org.wso2.carbon.crypto.provider.hsm/src/test/java/resources/testng.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite thread-count="1" verbose="0" name="Surefire suite">
+    <test name="Surefire test">
+        <classes>
+            <class name="org.wso2.carbon.crypto.provider.hsm.HSMBasedInternalCryptoProviderTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.HSMBasedKeyResolverTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.KeyTemplateGeneratorTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.MechanismResolverTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandlerTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.CertificateHandlerTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandlerTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators.CipherTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.cryptoprovider.operators.SignatureHandlerTest"/>
+            <class name="org.wso2.carbon.crypto.provider.hsm.HSMBasedExternalCryptoProviderTest"/>
+        </classes>
+    </test>
+</suite>

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/pom.xml
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>carbon-crypto-provider-hsm</artifactId>
         <groupId>org.wso2.carbon.crypto</groupId>
-        <version>1.0.0</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -94,7 +94,9 @@
                             org.wso2.carbon.crypto.api; version="${carbon.crypto.api.imp.pkg.version.range}",
                             org.wso2.carbon.core.util.*; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.stratos.common.*; version="${carbon.commons.imp.pkg.version}",
-                            org.wso2.carbon.crypto.provider.hsm.*,
+                            org.wso2.carbon.crypto.provider.hsm,
+                            org.wso2.carbon.crypto.provider.hsm.storemanager,
+                            org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util,
                             iaik.pkcs.pkcs11.*; version="${pkcs11.wrapper.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/pom.xml
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>carbon-crypto-provider-hsm</artifactId>
+        <groupId>org.wso2.carbon.crypto</groupId>
+        <version>1.0.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.crypto.tenant.hsmstore.mgt</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.commons</groupId>
+            <artifactId>org.wso2.carbon.tenant.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.crypto</groupId>
+            <artifactId>org.wso2.carbon.crypto.provider.hsm</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <version>${maven.scr.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <obrRepository>NONE</obrRepository>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Private-Package>org.wso2.carbon.crypto.tenant.hsmstore.mgt.internal</Private-Package>
+                        <Import-Package>
+                            org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+                            org.apache.commons.lang; version="${commons-lang.version.range}",
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.base.*; version="${carbon.base.osgi.version.range}",
+                            org.wso2.carbon.crypto.api; version="${carbon.crypto.api.imp.pkg.version.range}",
+                            org.wso2.carbon.core.util.*; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.stratos.common.*; version="${carbon.commons.imp.pkg.version}",
+                            org.wso2.carbon.crypto.provider.hsm.*,
+                            iaik.pkcs.pkcs11.*; version="${pkcs11.wrapper.imp.pkg.version.range}",
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.crypto.tenant.hsmstore.mgt.internal,
+                            org.wso2.carbon.crypto.tenant.hsmstore.mgt; version="${project.version}",
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/HSMStoreManager.java
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/HSMStoreManager.java
@@ -1,0 +1,106 @@
+package org.wso2.carbon.crypto.tenant.hsmstore.mgt;
+
+import iaik.pkcs.pkcs11.Session;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.crypto.api.CryptoContext;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.crypto.provider.hsm.DefaultSlotResolver;
+import org.wso2.carbon.crypto.provider.hsm.PKCS11CertificateData;
+import org.wso2.carbon.crypto.provider.hsm.PKCS11JCEObjectMapper;
+import org.wso2.carbon.crypto.provider.hsm.SlotInfo;
+import org.wso2.carbon.crypto.provider.hsm.SlotResolver;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.CertificateHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.objecthandlers.KeyHandler;
+import org.wso2.carbon.crypto.provider.hsm.cryptoprovider.util.SessionHandler;
+import org.wso2.carbon.crypto.tenant.hsmstore.mgt.internal.HSMTenantMgtDataHolder;
+import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
+import org.wso2.carbon.stratos.common.exception.StratosException;
+
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+
+public class HSMStoreManager {
+
+    private static Log log = LogFactory.getLog(HSMStoreManager.class);
+
+    private ServerConfigurationService serverConfigurationService;
+    private SessionHandler sessionHandler;
+    private SlotResolver slotResolver;
+
+    public HSMStoreManager() throws StratosException {
+
+        this.serverConfigurationService = HSMTenantMgtDataHolder.getServerConfigurationService();
+        this.slotResolver = new DefaultSlotResolver(serverConfigurationService);
+        try {
+            sessionHandler = SessionHandler.getDefaultSessionHandler(serverConfigurationService);
+        } catch (CryptoException e) {
+            String errorMessage = "Error occurred while retrieving the SessionHandler default instance.";
+            throw new StratosException(errorMessage, e);
+        }
+    }
+
+    public void storeTenantKeyStore(TenantInfoBean tenantInfoBean) throws StratosException {
+
+        PrivateKey privateKey;
+        Certificate certificate;
+        try {
+            KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantInfoBean.getTenantId());
+            String keyStoreName = getTenantKeyStoreName(tenantInfoBean.getTenantDomain());
+            privateKey = (PrivateKey) keyStoreManager.getPrivateKey(keyStoreName,
+                    tenantInfoBean.getTenantDomain());
+            certificate = keyStoreManager.getKeyStore(keyStoreName)
+                    .getCertificate(tenantInfoBean.getTenantDomain());
+            logDebug(String.format("Successfully retrieved private key and public certificate of tenant : '%s'",
+                    tenantInfoBean.getTenantDomain()));
+        } catch (Exception e) {
+            String errorMessage = String.format("Error occurred while retrieving public certificate and " +
+                    "private key of tenant : %s", tenantInfoBean.getTenantDomain());
+            throw new StratosException(errorMessage, e);
+        }
+        try {
+            PKCS11CertificateData pkcs11CertificateData = PKCS11JCEObjectMapper.mapCertificateJCEToPKCS11(certificate);
+            iaik.pkcs.pkcs11.objects.PrivateKey privateKeyToStore =
+                    PKCS11JCEObjectMapper.mapPrivateKeyJCEToPKCS11(privateKey);
+            privateKeyToStore.getLabel().setCharArrayValue(tenantInfoBean.getTenantDomain().toCharArray());
+            pkcs11CertificateData.getCertificate().getLabel().
+                    setCharArrayValue(tenantInfoBean.getTenantDomain().toCharArray());
+            pkcs11CertificateData.getPublicKey().getLabel().
+                    setCharArrayValue(tenantInfoBean.getTenantDomain().toCharArray());
+            Session session = initiateSession(CryptoContext.buildEmptyContext(tenantInfoBean.getTenantId(),
+                    tenantInfoBean.getTenantDomain()));
+            KeyHandler keyHandler = new KeyHandler(session);
+            CertificateHandler certificateHandler = new CertificateHandler(session);
+            keyHandler.storeKey(privateKeyToStore);
+            keyHandler.storeKey(pkcs11CertificateData.getPublicKey());
+            certificateHandler.storeCertificate(pkcs11CertificateData.getCertificate());
+            logDebug(String.format("Successfully stored private key and public certificate of tenant : '%s' " +
+                    "in HSM device.", tenantInfoBean.getTenantDomain()));
+            sessionHandler.closeSession(session);
+        } catch (CryptoException e) {
+            String errorMessage = String.format("Error occurred while storing the public certificate and private " +
+                    "key of tenant : %s", tenantInfoBean.getTenantDomain());
+            throw new StratosException(errorMessage);
+        }
+    }
+
+    protected Session initiateSession(CryptoContext cryptoContext) throws CryptoException {
+
+        SlotInfo slotInfo = slotResolver.resolveSlot(cryptoContext);
+        return sessionHandler.initiateSession(slotInfo.getSlotID(), slotInfo.getPin(), true);
+    }
+
+    protected String getTenantKeyStoreName(String tenantDomain) {
+
+        return tenantDomain.trim().replace(".", "-") + ".jks";
+    }
+
+    protected void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/HSMTenantMgtListener.java
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/HSMTenantMgtListener.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.tenant.hsmstore.mgt;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.crypto.api.CryptoException;
+import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
+import org.wso2.carbon.stratos.common.exception.StratosException;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+
+/**
+ * Implementation of {@link TenantMgtListener} which stores private key and public certificate of the
+ * created tenant in the HSM device.
+ */
+public class HSMTenantMgtListener implements TenantMgtListener {
+
+    private static final int EXEC_ORDER = 21;
+    private static Log log = LogFactory.getLog(HSMTenantMgtListener.class);
+
+    /**
+     * Constructor of {@link HSMTenantMgtListener}.
+     *
+     * @throws CryptoException
+     */
+    public HSMTenantMgtListener() throws CryptoException {
+
+    }
+
+    /**
+     * This method retrieves the generated keystore at the tenant creation, using {@link KeyStoreManager} and
+     * stores the public certificate and private key in the HSM device.
+     *
+     * @param tenantInfoBean : Bean which stores information related to created tenant.
+     * @throws StratosException
+     */
+    @Override
+    public void onTenantCreate(TenantInfoBean tenantInfoBean) throws StratosException {
+
+        logDebug(String.format("Storing '%s' tenant private key and public key in HSM store.",
+                tenantInfoBean.getTenantDomain()));
+        if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantInfoBean.getTenantDomain())) {
+            String errorMessage = "Super tenant domain can't be a new tenant domain.";
+            throw new StratosException(errorMessage);
+        }
+        HSMStoreManager hsmStoreManager = new HSMStoreManager();
+        hsmStoreManager.storeTenantKeyStore(tenantInfoBean);
+    }
+
+    @Override
+    public void onTenantUpdate(TenantInfoBean tenantInfo) throws StratosException {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public void onTenantDelete(int tenantId) {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public void onTenantRename(int tenantId, String oldDomainName,
+                               String newDomainName) throws StratosException {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public int getListenerOrder() {
+
+        return EXEC_ORDER;
+    }
+
+    @Override
+    public void onTenantInitialActivation(int tenantId) throws StratosException {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public void onTenantActivation(int tenantId) throws StratosException {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public void onTenantDeactivation(int tenantId) throws StratosException {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public void onSubscriptionPlanChange(int tenentId, String oldPlan,
+                                         String newPlan) throws StratosException {
+        // It is not required to implement this method for keystore mgt.
+    }
+
+    @Override
+    public void onPreDelete(int tenantId) throws StratosException {
+        //Implement this method to delete product specific data
+    }
+
+    protected void logDebug(String message) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(message);
+        }
+    }
+}

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/HSMTenantMgtListener.java
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/HSMTenantMgtListener.java
@@ -110,7 +110,7 @@ public class HSMTenantMgtListener implements TenantMgtListener {
 
     @Override
     public void onPreDelete(int tenantId) throws StratosException {
-        //Implement this method to delete product specific data
+        // Implement this method to delete product specific data
     }
 
     protected void logDebug(String message) {

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/internal/HSMTenantMgtComponent.java
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/internal/HSMTenantMgtComponent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.crypto.tenant.hsmstore.mgt.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.tenant.hsmstore.mgt.HSMTenantMgtListener;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+
+/**
+ * The class which is used to deal with the OSGi runtime for service registration and injection.
+ */
+@Component(
+        name = "org.wso2.carbon.crypto.tenant.hsmstore.mgt",
+        immediate = true
+)
+public class HSMTenantMgtComponent {
+
+    private static final Log log = LogFactory.getLog(HSMTenantMgtComponent.class);
+
+    private ServiceRegistration<TenantMgtListener> hsmTenantMgtListenerServiceRegistration;
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+
+        try {
+            BundleContext bundleContext = componentContext.getBundleContext();
+            HSMTenantMgtListener hsmTenantMgtListener = new HSMTenantMgtListener();
+            hsmTenantMgtListenerServiceRegistration = bundleContext.registerService(TenantMgtListener.class,
+                    hsmTenantMgtListener, null);
+        } catch (Throwable e) {
+            String errorMessage = "An error occurred while activating HSM tenant management listener.";
+            log.error(errorMessage, e);
+        }
+        if (log.isInfoEnabled()) {
+            log.info("HSM tenant management listener has been activated successfully.");
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+
+        hsmTenantMgtListenerServiceRegistration.unregister();
+    }
+
+    @Reference(
+            name = "serverConfigurationService",
+            service = ServerConfigurationService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            unbind = "unsetServerConfigurationService"
+    )
+    protected void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        HSMTenantMgtDataHolder.setServerConfigurationService(serverConfigurationService);
+    }
+
+    protected void unsetServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        HSMTenantMgtDataHolder.unsetServerConfigurationService();
+    }
+}

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/internal/HSMTenantMgtDataHolder.java
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/internal/HSMTenantMgtDataHolder.java
@@ -1,6 +1,25 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.crypto.tenant.hsmstore.mgt.internal;
 
 import org.wso2.carbon.base.api.ServerConfigurationService;
+import org.wso2.carbon.crypto.provider.hsm.storemanager.HSMStoreManagerService;
 
 /**
  * This class holds data required for functionality of the HSM Store component.
@@ -8,6 +27,7 @@ import org.wso2.carbon.base.api.ServerConfigurationService;
 public class HSMTenantMgtDataHolder {
 
     private static ServerConfigurationService serverConfigurationService;
+    private static HSMStoreManagerService hsmStoreManagerService;
 
     public static void unsetServerConfigurationService() {
 
@@ -22,5 +42,20 @@ public class HSMTenantMgtDataHolder {
     public static void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
 
         HSMTenantMgtDataHolder.serverConfigurationService = serverConfigurationService;
+    }
+
+    public static HSMStoreManagerService getHsmStoreManagerService() {
+
+        return hsmStoreManagerService;
+    }
+
+    public static void setHsmStoreManagerService(HSMStoreManagerService hsmStoreManagerService) {
+
+        HSMTenantMgtDataHolder.hsmStoreManagerService = hsmStoreManagerService;
+    }
+
+    public static void unsetHsmStoreManagerService() {
+
+        HSMTenantMgtDataHolder.hsmStoreManagerService = null;
     }
 }

--- a/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/internal/HSMTenantMgtDataHolder.java
+++ b/components/org.wso2.carbon.crypto.tenant.hsmstore.mgt/src/main/java/org/wso2/carbon/crypto/tenant/hsmstore/mgt/internal/HSMTenantMgtDataHolder.java
@@ -1,0 +1,26 @@
+package org.wso2.carbon.crypto.tenant.hsmstore.mgt.internal;
+
+import org.wso2.carbon.base.api.ServerConfigurationService;
+
+/**
+ * This class holds data required for functionality of the HSM Store component.
+ */
+public class HSMTenantMgtDataHolder {
+
+    private static ServerConfigurationService serverConfigurationService;
+
+    public static void unsetServerConfigurationService() {
+
+        HSMTenantMgtDataHolder.serverConfigurationService = null;
+    }
+
+    public static ServerConfigurationService getServerConfigurationService() {
+
+        return serverConfigurationService;
+    }
+
+    public static void setServerConfigurationService(ServerConfigurationService serverConfigurationService) {
+
+        HSMTenantMgtDataHolder.serverConfigurationService = serverConfigurationService;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>org.wso2.carbon.crypto</groupId>
     <artifactId>carbon-crypto-provider-hsm</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <repositories>
         <repository>
@@ -110,11 +110,6 @@
                 <groupId>org.wso2.carbon.crypto</groupId>
                 <artifactId>org.wso2.carbon.crypto.api</artifactId>
                 <version>${carbon.crypto.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.core</artifactId>
-                <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.commons</groupId>
@@ -288,7 +283,7 @@
         <pkcs11.wrapper.imp.pkg.version.range>[0.0.0, 1.0.0]</pkcs11.wrapper.imp.pkg.version.range>
 
         <!-- Dependency versions -->
-        <carbon.kernel.version>4.4.11</carbon.kernel.version>
+        <carbon.kernel.version>4.4.36</carbon.kernel.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <equinox.osgi.version>3.9.1.v20130814-1242</equinox.osgi.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.carbon.crypto</groupId>
+    <artifactId>carbon-crypto-provider-hsm</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wso2.carbon.pkcs11</groupId>
+                <artifactId>org.wso2.carbon.pkcs11.wrapper</artifactId>
+                <version>${carbon.pkcs11.wrapper.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.crypto</groupId>
+                <artifactId>org.wso2.carbon.crypto.api</artifactId>
+                <version>${carbon.crypto.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.core</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.commons</groupId>
+                <artifactId>org.wso2.carbon.tenant.common</artifactId>
+                <version>${carbon.commons.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.core</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.osgi</groupId>
+                <artifactId>org.eclipse.osgi</artifactId>
+                <version>${equinox.osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.eclipse.osgi</groupId>
+                <artifactId>org.eclipse.osgi.services</artifactId>
+                <version>${equinox.osgi.services.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+                <version>${org.apache.felix.annotations.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.base</artifactId>
+                <version>${carbon.kernel.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang.wso2</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.wso2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jmockit</groupId>
+                <artifactId>jmockit</artifactId>
+                <scope>test</scope>
+                <version>${jmockit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <classifier>runtime</classifier>
+                <version>${jacoco.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-testng</artifactId>
+                <version>${org.powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${org.powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-testng-common</artifactId>
+                <version>${org.powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+            <version>${carbon.kernel.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-scr-plugin</artifactId>
+                    <version>${maven.scr.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>generate-scr-scrdescriptor</id>
+                            <goals>
+                                <goal>scr</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven.bundle.plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <obrRepository>NONE</obrRepository>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>${maven.buildnumber.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <doCheck>false</doCheck>
+                        <doUpdate>false</doUpdate>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <preparationGoals>clean install</preparationGoals>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <!-- Dependency import version ranges -->
+        <carbon.crypto.api.imp.pkg.version.range>[1.0.0,1.1.0)</carbon.crypto.api.imp.pkg.version.range>
+        <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>
+        <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
+        <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <carbon.base.osgi.version.range>[1.0.0,1.1.0)</carbon.base.osgi.version.range>
+        <commons-lang.version.range>[2.6.0, 3.0.0]</commons-lang.version.range>
+        <carbon.commons.imp.pkg.version>[4.4.0, 5.0.0)</carbon.commons.imp.pkg.version>
+        <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
+        <pkcs11.wrapper.imp.pkg.version.range>[0.0.0, 1.0.0]</pkcs11.wrapper.imp.pkg.version.range>
+
+        <!-- Dependency versions -->
+        <carbon.kernel.version>4.4.11</carbon.kernel.version>
+        <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
+        <equinox.osgi.version>3.9.1.v20130814-1242</equinox.osgi.version>
+        <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
+        <org.apache.felix.annotations.version>1.2.4</org.apache.felix.annotations.version>
+        <carbon.commons.version>4.5.2</carbon.commons.version>
+        <carbon.pkcs11.wrapper.version>1.0.0</carbon.pkcs11.wrapper.version>
+        <carbon.crypto.api.version>1.0.3</carbon.crypto.api.version>
+
+        <!-- Plugin versions -->
+        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <maven.scr.plugin.version>1.22.0</maven.scr.plugin.version>
+        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
+        <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
+        <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
+
+        <!-- Test versions -->
+        <testng.version>6.9.10</testng.version>
+        <jacoco.version>0.7.9</jacoco.version>
+        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <org.powermock.version>1.7.3</org.powermock.version>
+        <jmockit.version>1.35</jmockit.version>
+    </properties>
+
+    <modules>
+        <module>components/org.wso2.carbon.crypto.provider.hsm</module>
+        <module>components/org.wso2.carbon.crypto.tenant.hsmstore.mgt</module>
+    </modules>
+</project>


### PR DESCRIPTION
## Purpose
> This is the first implementation of carbon-crypto-provider-hsm. This component provides an implementation of Carbon Crypto Service API to provide HSM based cryptographic operations. 

## When should this PR be merged
- Depends on PR - https://github.com/wso2/carbon-crypto-service/pull/9